### PR TITLE
Re-export `simd_backend`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ p256 = ["num-bigint", "num-integer", "num-traits", "once_cell", "p256_"]
 std = ["curve25519-dalek/std", "getrandom", "rand/std", "rand/std_rng", "num-bigint/std", "num-integer/std", "num-traits/std"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
+simd_backend = ["curve25519-dalek/simd_backend"]
 serialize = ["serde", "base64", "generic-array/serde", "curve25519-dalek/serde"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,6 +468,10 @@
 //! - The `u32_backend` and `u64_backend` features are re-exported from
 //! [curve25519-dalek](https://doc.dalek.rs/curve25519_dalek/index.html#backends-and-features) and allow for selecting
 //! the corresponding backend for the curve arithmetic used. The `u64_backend` feature is included as the default.
+//!
+//! - The `simd_backend` feature is re-exported from
+//! [curve25519-dalek](https://doc.dalek.rs/curve25519_dalek/index.html#backends-and-features) and enables parallel formulas,
+//! using either AVX2 or AVX512-IFMA. This will automatically enable the `u64_backend` and requires Rust nightly.
 
 #![cfg_attr(not(feature = "bench"), deny(missing_docs))]
 #![deny(unsafe_code)]


### PR DESCRIPTION
See novifinancial/opaque-ke#187.