### PR TITLE
Adding deterministic_blind_unchecked functionality under danger feature

### DIFF
--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -87,20 +87,9 @@ impl Group for RistrettoPoint {
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
         loop {
             let scalar = {
-                #[cfg(not(test))]
-                {
-                    let mut scalar_bytes = [0u8; 64];
-                    rng.fill_bytes(&mut scalar_bytes);
-                    Scalar::from_bytes_mod_order_wide(&scalar_bytes)
-                }
-
-                // Tests need an exact conversion from bytes to scalar, sampling only 32 bytes from rng
-                #[cfg(test)]
-                {
-                    let mut scalar_bytes = [0u8; 32];
-                    rng.fill_bytes(&mut scalar_bytes);
-                    Scalar::from_bytes_mod_order(scalar_bytes)
-                }
+                let mut scalar_bytes = [0u8; 64];
+                rng.fill_bytes(&mut scalar_bytes);
+                Scalar::from_bytes_mod_order_wide(&scalar_bytes)
             };
 
             if scalar != Scalar::zero() {

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -173,9 +173,12 @@ fn test_base_blind<G: Group, H: BlockInput + Digest>(
 ) -> Result<(), InternalError> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
-            let mut rng = CycleRng::new(parameters.blind[i].to_vec());
-            let client_result =
-                NonVerifiableClient::<G, H>::blind(parameters.input[i].clone(), &mut rng)?;
+            let blind =
+                G::from_scalar_slice(&GenericArray::clone_from_slice(&parameters.blind[i]))?;
+            let client_result = NonVerifiableClient::<G, H>::deterministic_blind_unchecked(
+                parameters.input[i].clone(),
+                blind,
+            )?;
 
             assert_eq!(
                 &parameters.blind[i],
@@ -196,9 +199,12 @@ fn test_verifiable_blind<G: Group, H: BlockInput + Digest>(
 ) -> Result<(), InternalError> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
-            let mut rng = CycleRng::new(parameters.blind[i].to_vec());
-            let client_blind_result =
-                VerifiableClient::<G, H>::blind(parameters.input[i].clone(), &mut rng)?;
+            let blind =
+                G::from_scalar_slice(&GenericArray::clone_from_slice(&parameters.blind[i]))?;
+            let client_blind_result = VerifiableClient::<G, H>::deterministic_blind_unchecked(
+                parameters.input[i].clone(),
+                blind,
+            )?;
 
             assert_eq!(
                 &parameters.blind[i],
@@ -291,7 +297,7 @@ fn test_verifiable_finalize<G: Group, H: BlockInput + Digest>(
     for parameters in tvs {
         let mut clients = vec![];
         for i in 0..parameters.input.len() {
-            let client = VerifiableClient::<G, H>::from_data_and_blind(
+            let client = VerifiableClient::<G, H>::from_data_and_blind_and_element(
                 &parameters.input[i],
                 <G as Group>::from_scalar_slice(&GenericArray::clone_from_slice(
                     &parameters.blind[i],


### PR DESCRIPTION
This introduces the `deterministic_blind_unchecked` functions which allow for blinding where the consumer can supply a scalar value to use as the blinding factor, as opposed to sampling it from an rng.

This is put under the `danger` feature, since it can be useful for being called by other libraries that perform these checks already without needing to rely on an rng.