### PR TITLE
No `alloc` experiment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,8 @@ jobs:
           - ristretto255_u64,p256
         frontend_feature:
           -
-          - --features serde
           - --features danger
+          - --features serde
         toolchain:
           - stable
           - 1.51.0
@@ -63,6 +63,12 @@ jobs:
         with:
           command: test
           args: --no-default-features --features ${{ matrix.backend_feature }}
+
+      - name: Run cargo test with alloc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features ${{ matrix.frontend_feature }},alloc --features ${{ matrix.backend_feature }}
 
       - name: Run cargo test with std
         uses: actions-rs/cargo@v1
@@ -88,8 +94,8 @@ jobs:
           - --features p256
         frontend_feature:
           -
-          - --features serde
           - --features danger
+          - --features serde
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,24 @@ rust-version = "1.51.0"
 version = "0.3.0"
 
 [features]
+alloc = []
 danger = []
 default = ["ristretto255_u64", "serde"]
-p256 = ["num-bigint", "num-integer", "num-traits", "once_cell", "p256_"]
+p256 = [
+  "alloc",
+  "num-bigint",
+  "num-integer",
+  "num-traits",
+  "once_cell",
+  "p256_",
+]
 ristretto255 = []
 ristretto255_fiat_u32 = ["curve25519-dalek/fiat_u32_backend", "ristretto255"]
 ristretto255_fiat_u64 = ["curve25519-dalek/fiat_u64_backend", "ristretto255"]
 ristretto255_simd = ["curve25519-dalek/simd_backend", "ristretto255"]
 ristretto255_u32 = ["curve25519-dalek/u32_backend", "ristretto255"]
 ristretto255_u64 = ["curve25519-dalek/u64_backend", "ristretto255"]
-std = []
+std = ["alloc"]
 
 [dependencies]
 curve25519-dalek = { version = "3", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,8 @@
 //!     server.get_public_key(),
 //!     None,
 //! )
-//! .expect("Unable to perform client batch finalization");
+//! .expect("Unable to perform client batch finalization")
+//! .collect::<Vec<_>>();
 //!
 //! println!("VOPRF batch outputs: {:?}", client_batch_finalize_result);
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,8 @@
 //! use voprf::NonVerifiableClient;
 //!
 //! let mut client_rng = OsRng;
-//! let client_blind_result =
-//!     NonVerifiableClient::<Group, Hash>::blind(b"input".to_vec(), &mut client_rng)
-//!         .expect("Unable to construct client");
+//! let client_blind_result = NonVerifiableClient::<Group, Hash>::blind(b"input", &mut client_rng)
+//!     .expect("Unable to construct client");
 //! ```
 //!
 //! ### Server Evaluation
@@ -117,7 +116,7 @@
 //! #
 //! # let mut client_rng = OsRng;
 //! # let client_blind_result = NonVerifiableClient::<Group, Hash>::blind(
-//! #     b"input".to_vec(),
+//! #     b"input",
 //! #     &mut client_rng,
 //! # ).expect("Unable to construct client");
 //! # use voprf::NonVerifiableServer;
@@ -149,7 +148,7 @@
 //! #
 //! # let mut client_rng = OsRng;
 //! # let client_blind_result = NonVerifiableClient::<Group, Hash>::blind(
-//! #     b"input".to_vec(),
+//! #     b"input",
 //! #     &mut client_rng,
 //! # ).expect("Unable to construct client");
 //! # use voprf::NonVerifiableServer;
@@ -162,7 +161,7 @@
 //! # ).expect("Unable to perform server evaluate");
 //! let client_finalize_result = client_blind_result
 //!     .state
-//!     .finalize(&server_evaluate_result.message, None)
+//!     .finalize(b"input", &server_evaluate_result.message, None)
 //!     .expect("Unable to perform client finalization");
 //!
 //! println!("VOPRF output: {:?}", client_finalize_result.to_vec());
@@ -233,9 +232,8 @@
 //! use voprf::VerifiableClient;
 //!
 //! let mut client_rng = OsRng;
-//! let client_blind_result =
-//!     VerifiableClient::<Group, Hash>::blind(b"input".to_vec(), &mut client_rng)
-//!         .expect("Unable to construct client");
+//! let client_blind_result = VerifiableClient::<Group, Hash>::blind(b"input", &mut client_rng)
+//!     .expect("Unable to construct client");
 //! ```
 //!
 //! ### Server Evaluation
@@ -260,7 +258,7 @@
 //! #
 //! # let mut client_rng = OsRng;
 //! # let client_blind_result = VerifiableClient::<Group, Hash>::blind(
-//! #     b"input".to_vec(),
+//! #     b"input",
 //! #     &mut client_rng,
 //! # ).expect("Unable to construct client");
 //! # use voprf::VerifiableServer;
@@ -293,7 +291,7 @@
 //! #
 //! # let mut client_rng = OsRng;
 //! # let client_blind_result = VerifiableClient::<Group, Hash>::blind(
-//! #     b"input".to_vec(),
+//! #     b"input",
 //! #     &mut client_rng,
 //! # ).expect("Unable to construct client");
 //! # use voprf::VerifiableServer;
@@ -308,6 +306,7 @@
 //! let client_finalize_result = client_blind_result
 //!     .state
 //!     .finalize(
+//!         b"input",
 //!         &server_evaluate_result.message,
 //!         &server_evaluate_result.proof,
 //!         server.get_public_key(),
@@ -351,9 +350,8 @@
 //! let mut client_states = vec![];
 //! let mut client_messages = vec![];
 //! for _ in 0..10 {
-//!     let client_blind_result =
-//!         VerifiableClient::<Group, Hash>::blind(b"input".to_vec(), &mut client_rng)
-//!             .expect("Unable to construct client");
+//!     let client_blind_result = VerifiableClient::<Group, Hash>::blind(b"input", &mut client_rng)
+//!         .expect("Unable to construct client");
 //!     client_states.push(client_blind_result.state);
 //!     client_messages.push(client_blind_result.message);
 //! }
@@ -381,7 +379,7 @@
 //! # let mut client_messages = vec![];
 //! # for _ in 0..10 {
 //! #     let client_blind_result = VerifiableClient::<Group, Hash>::blind(
-//! #         b"input".to_vec(),
+//! #         b"input",
 //! #        &mut client_rng,
 //! #     ).expect("Unable to construct client");
 //! #     client_states.push(client_blind_result.state);
@@ -418,7 +416,7 @@
 //! # let mut client_messages = vec![];
 //! # for _ in 0..10 {
 //! #     let client_blind_result = VerifiableClient::<Group, Hash>::blind(
-//! #         b"input".to_vec(),
+//! #         b"input",
 //! #        &mut client_rng,
 //! #     ).expect("Unable to construct client");
 //! #     client_states.push(client_blind_result.state);
@@ -434,6 +432,7 @@
 //! #     None,
 //! # ).expect("Unable to perform server batch evaluate");
 //! let client_batch_finalize_result = VerifiableClient::batch_finalize(
+//!     &[b"input"; 10],
 //!     &client_states,
 //!     &server_batch_evaluate_result.messages,
 //!     &server_batch_evaluate_result.proof,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,10 +331,13 @@
 //! this case. In the following example, we show how to use the batch API to
 //! produce a single proof for 10 parallel VOPRF evaluations.
 //!
+//! This requires the crate feature `alloc`.
+//!
 //! First, the client produces 10 blindings, storing their resulting states and
 //! messages:
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! # #[cfg(feature = "ristretto255")]
 //! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! # #[cfg(feature = "ristretto255")]
@@ -355,6 +358,7 @@
 //!     client_states.push(client_blind_result.state);
 //!     client_messages.push(client_blind_result.message);
 //! }
+//! # }
 //! ```
 //!
 //! Next, the server calls the [VerifiableServer::batch_evaluate] function on a
@@ -363,6 +367,7 @@
 //! proof:
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! # #[cfg(feature = "ristretto255")]
 //! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! # #[cfg(feature = "ristretto255")]
@@ -392,6 +397,7 @@
 //! let server_batch_evaluate_result = server
 //!     .batch_evaluate(&mut server_rng, &client_messages, None)
 //!     .expect("Unable to perform server batch evaluate");
+//! # }
 //! ```
 //!
 //! Then, the client calls [VerifiableClient::batch_finalize] on the client
@@ -400,6 +406,7 @@
 //! outputs if the proof verifies correctly.
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! # #[cfg(feature = "ristretto255")]
 //! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! # #[cfg(feature = "ristretto255")]
@@ -443,6 +450,7 @@
 //! .collect::<Vec<_>>();
 //!
 //! println!("VOPRF batch outputs: {:?}", client_batch_finalize_result);
+//! # }
 //! ```
 //!
 //! ## Metadata
@@ -459,6 +467,9 @@
 //! `Some(b"custom metadata")`.
 //!
 //! # Features
+//!
+//! - The `alloc` feature requires Rusts [`alloc`] crate and enables batching
+//!   VOPRF evaluations.
 //!
 //! - The `p256` feature enables using p256 as the underlying group for the
 //!   [Group](group::Group) choice. Note that this is currently an experimental
@@ -491,6 +502,7 @@
 #![warn(clippy::cargo, missing_docs)]
 #![allow(clippy::multiple_crate_versions)]
 
+#[cfg(any(feature = "alloc", test))]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use digest::{BlockInput, Digest};
-use generic_array::typenum::Unsigned;
+use generic_array::{typenum::Unsigned, GenericArray};
 
 use crate::errors::InternalError;
 use crate::group::Group;
@@ -155,8 +155,8 @@ impl<G: Group, H: BlockInput + Digest> Proof<G, H> {
 
 impl<G: Group, H: BlockInput + Digest> BlindedElement<G, H> {
     /// Serialization into bytes
-    pub fn serialize(&self) -> Vec<u8> {
-        self.value.to_arr().to_vec()
+    pub fn serialize(&self) -> GenericArray<u8, G::ElemLen> {
+        self.value.to_arr()
     }
 
     /// Deserialization from bytes

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+#[cfg(feature = "alloc")]
 mod mock_rng;
 mod parser;
 mod voprf_test_vectors;

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -327,9 +327,8 @@ fn test_verifiable_finalize<G: Group, H: BlockInput + Digest>(
         assert_eq!(
             parameters.output,
             batch_result
-                .iter()
-                .map(|arr| arr.to_vec())
-                .collect::<Vec<Vec<u8>>>()
+                .map(|arr| arr.map(|message| message.to_vec()))
+                .collect::<Result<Vec<_>, _>>()?
         );
     }
     Ok(())

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -8,15 +8,19 @@
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Add;
 
 use digest::{BlockInput, Digest};
-use generic_array::typenum::Sum;
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::GenericArray;
 use json::JsonValue;
+#[cfg(feature = "alloc")]
+use ::{
+    core::ops::Add,
+    generic_array::{typenum::Sum, ArrayLength},
+};
 
 use crate::errors::InternalError;
 use crate::group::Group;
+#[cfg(feature = "alloc")]
 use crate::tests::mock_rng::CycleRng;
 use crate::tests::parser::*;
 use crate::voprf::{
@@ -35,6 +39,7 @@ struct VOPRFTestVectorParameters {
     blinded_element: Vec<Vec<u8>>,
     evaluation_element: Vec<Vec<u8>>,
     proof: Vec<u8>,
+    #[cfg(feature = "alloc")]
     proof_random_scalar: Vec<u8>,
     output: Vec<Vec<u8>>,
 }
@@ -50,6 +55,7 @@ fn populate_test_vectors(values: &JsonValue) -> VOPRFTestVectorParameters {
         blinded_element: decode_vec(values, "BlindedElement"),
         evaluation_element: decode_vec(values, "EvaluationElement"),
         proof: decode(values, "Proof"),
+        #[cfg(feature = "alloc")]
         proof_random_scalar: decode(values, "ProofRandomScalar"),
         output: decode_vec(values, "Output"),
     }
@@ -113,6 +119,7 @@ fn test_vectors() -> Result<(), InternalError> {
 
         test_verifiable_seed_to_key::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
         test_verifiable_blind::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
+        #[cfg(feature = "alloc")]
         test_verifiable_evaluate::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
         test_verifiable_finalize::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
     }
@@ -247,6 +254,7 @@ fn test_base_evaluate<G: Group, H: BlockInput + Digest>(
     Ok(())
 }
 
+#[cfg(feature = "alloc")]
 fn test_verifiable_evaluate<G: Group, H: BlockInput + Digest>(
     tvs: &[VOPRFTestVectorParameters],
 ) -> Result<(), InternalError>

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -190,8 +190,8 @@ fn test_base_blind<G: Group, H: BlockInput + Digest>(
                 &G::scalar_as_bytes(client_result.state.blind).to_vec()
             );
             assert_eq!(
-                &parameters.blinded_element[i],
-                &client_result.message.serialize()
+                parameters.blinded_element[i].as_slice(),
+                client_result.message.serialize().as_slice(),
             );
         }
     }
@@ -216,8 +216,8 @@ fn test_verifiable_blind<G: Group, H: BlockInput + Digest>(
                 &G::scalar_as_bytes(client_blind_result.state.get_blind()).to_vec()
             );
             assert_eq!(
-                &parameters.blinded_element[i],
-                &client_blind_result.message.serialize()
+                parameters.blinded_element[i].as_slice(),
+                client_blind_result.message.serialize().as_slice(),
             );
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -103,7 +103,7 @@ macro_rules! chain_skip {
     };
 }
 
-/// The purpose of this macro is to simplify
+/// The purpose of this macro is to replace
 /// [`concat`](alloc::slice::Concat::concat)ing slices into an [`Iterator`] to
 /// avoid allocation
 macro_rules! chain {

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -1150,7 +1150,7 @@ mod tests {
             .concat(get_context_string::<G>(Mode::Base).unwrap());
         let point = G::hash_to_curve::<H, _>(&input, dst).unwrap();
         let res2 = finalize_after_unblind::<G, H, _, _>(
-            Some((input.as_slice(), point)).into_iter(),
+            Some((input.as_ref(), point)).into_iter(),
             info,
             Mode::Base,
         )


### PR DESCRIPTION
This adds support for removing the requirement for `alloc` from the crate. Following changes were introduced:
- All serialization returns `GenericArray<u8, _>` instead of `Vec<u8>` and requires some `where` bounds, which shouldn't affect the user unless they are using a generic interface themselves.
- `NonVerifiableClient` and `VerifiableClient` don't hold data anymore, that way the user has to store the data and we don't have to bind our items by lifetimes. This also makes serialization without allocation possible, because we have a known size now. Alternatively we could either introduce a lifetimes to these items, or introduce a generic that can be `AsRef<u8>` to own the `data` without allocation. Both would make `serialization` without `alloc` support impossible or difficult.
- `batch_evaluate` is now only supported with `alloc`, because I have no clue how to support it without allocating memory to save the generated `EvaluationElement`s.
- `batch_finalize` now returns an `Iterator` instead of a `Vec`.

So the missing part to make it completely support building without `alloc` would be to split the `batch_evaluate` functions into two parts so output can be collected by the user without allocation. This is already done internally, so we can just make the interface public. We can still leave the original `batch_evaluate` as a convenience function for users that have support for `alloc`. What do you think @kevinlewi?

This builds on top of #34.