### PR TITLE
General Improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,11 @@ jobs:
         toolchain:
           - stable
           - 1.51.0
+        exclude:
+        - backend_feature: p256
+          toolchain: 1.51.0
+        - backend_feature: ristretto255_u64,p256
+          toolchain: 1.51.0
     name: test
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,8 @@ num-bigint = { version = "0.4", default-features = false, optional = true }
 num-integer = { version = "0.1", default-features = false, optional = true }
 num-traits = { version = "0.2", default-features = false, optional = true }
 once_cell = { version = "1", default-features = false, optional = true }
-p256_ = { package = "p256", version = "0.9", default-features = false, features = [
+p256_ = { package = "p256", version = "0.10", default-features = false, features = [
   "arithmetic",
-  "zeroize",
 ], optional = true }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, features = [

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,15 +5,16 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-//! A list of error types which are produced during an execution of the protocol
-#[cfg(feature = "std")]
-use std::error::Error;
+//! Errors which are produced during an execution of the protocol
 
 use displaydoc::Display;
 
+/// [`Result`](core::result::Result) shorthand that uses [`Error`].
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Represents an error in the manipulation of internal cryptographic data
 #[derive(Clone, Copy, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum InternalError {
+pub enum Error {
     /// Could not parse byte sequence for key
     InvalidByteSequence,
     /// Could not deserialize element, or deserialized to the identity element
@@ -38,4 +39,4 @@ pub enum InternalError {
 }
 
 #[cfg(feature = "std")]
-impl Error for InternalError {}
+impl std::error::Error for Error {}

--- a/src/group/expand.rs
+++ b/src/group/expand.rs
@@ -13,8 +13,8 @@ use generic_array::sequence::Concat;
 use generic_array::typenum::{Unsigned, U1, U2};
 use generic_array::{ArrayLength, GenericArray};
 
-use crate::errors::InternalError;
 use crate::util::i2osp;
+use crate::{Error, Result};
 
 // Computes ceil(x / y)
 fn div_ceil(x: usize, y: usize) -> usize {
@@ -37,14 +37,14 @@ pub fn expand_message_xmd<
 >(
     msg: M,
     dst: GenericArray<u8, D>,
-) -> Result<GenericArray<u8, L>, InternalError>
+) -> Result<GenericArray<u8, L>>
 where
     <D as Add<U1>>::Output: ArrayLength<u8>,
 {
     let digest_len = H::OutputSize::USIZE;
     let ell = div_ceil(L::USIZE, digest_len);
     if ell > 255 {
-        return Err(InternalError::HashToCurveError);
+        return Err(Error::HashToCurveError);
     }
     let dst_prime = dst.concat(i2osp::<U1>(D::USIZE)?);
     let z_pad = i2osp::<H::BlockSize>(0)?;

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -33,7 +33,7 @@ use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable};
 
 use super::Group;
-use crate::errors::InternalError;
+use crate::{Error, Result};
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-8.2
 // `L: 48`
@@ -48,7 +48,7 @@ impl Group for ProjectivePoint {
     fn hash_to_curve<H: BlockSizeUser + Digest + FixedOutputReset, D: ArrayLength<u8> + Add<U1>>(
         msg: &[u8],
         dst: GenericArray<u8, D>,
-    ) -> Result<Self, InternalError>
+    ) -> Result<Self>
     where
         <D as Add<U1>>::Output: ArrayLength<u8>,
     {
@@ -88,12 +88,12 @@ impl Group for ProjectivePoint {
         let p0 = AffinePoint::from_encoded_point(&EncodedPoint::from_affine_coordinates(
             &q0x, &q0y, false,
         ))
-        .ok_or(InternalError::PointError)?
+        .ok_or(Error::PointError)?
         .to_curve();
         let p1 = AffinePoint::from_encoded_point(&EncodedPoint::from_affine_coordinates(
             &q1x, &q1y, false,
         ))
-        .ok_or(InternalError::PointError)?;
+        .ok_or(Error::PointError)?;
 
         Ok(p0 + p1)
     }
@@ -107,7 +107,7 @@ impl Group for ProjectivePoint {
     >(
         input: I,
         dst: GenericArray<u8, D>,
-    ) -> Result<Self::Scalar, InternalError>
+    ) -> Result<Self::Scalar>
     where
         <D as Add<U1>>::Output: ArrayLength<u8>,
     {
@@ -141,7 +141,7 @@ impl Group for ProjectivePoint {
 
     fn from_scalar_slice_unchecked(
         scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar, InternalError> {
+    ) -> Result<Self::Scalar> {
         Ok(Self::Scalar::from_bytes_reduced(scalar_bits))
     }
 
@@ -159,8 +159,8 @@ impl Group for ProjectivePoint {
 
     fn from_element_slice_unchecked(
         element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self, InternalError> {
-        Option::from(Self::from_bytes(element_bits)).ok_or(InternalError::PointError)
+    ) -> Result<Self> {
+        Option::from(Self::from_bytes(element_bits)).ok_or(Error::PointError)
     }
 
     fn to_arr(&self) -> GenericArray<u8, Self::ElemLen> {

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -19,7 +19,7 @@ use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
 
 use super::Group;
-use crate::errors::InternalError;
+use crate::{Error, Result};
 
 // `cfg` here is only needed because of a bug in Rust's crate feature documentation. See: https://github.com/rust-lang/rust/issues/83428
 #[cfg(feature = "ristretto255")]
@@ -32,7 +32,7 @@ impl Group for RistrettoPoint {
     fn hash_to_curve<H: BlockSizeUser + Digest + FixedOutputReset, D: ArrayLength<u8> + Add<U1>>(
         msg: &[u8],
         dst: GenericArray<u8, D>,
-    ) -> Result<Self, InternalError>
+    ) -> Result<Self>
     where
         <D as Add<U1>>::Output: ArrayLength<u8>,
     {
@@ -42,7 +42,7 @@ impl Group for RistrettoPoint {
             uniform_bytes
                 .as_slice()
                 .try_into()
-                .map_err(|_| InternalError::HashToCurveError)?,
+                .map_err(|_| Error::HashToCurveError)?,
         ))
     }
 
@@ -56,7 +56,7 @@ impl Group for RistrettoPoint {
     >(
         input: I,
         dst: GenericArray<u8, D>,
-    ) -> Result<Self::Scalar, InternalError>
+    ) -> Result<Self::Scalar>
     where
         <D as Add<U1>>::Output: ArrayLength<u8>,
     {
@@ -66,7 +66,7 @@ impl Group for RistrettoPoint {
             uniform_bytes
                 .as_slice()
                 .try_into()
-                .map_err(|_| InternalError::HashToCurveError)?,
+                .map_err(|_| Error::HashToCurveError)?,
         ))
     }
 
@@ -74,7 +74,7 @@ impl Group for RistrettoPoint {
     type ScalarLen = U32;
     fn from_scalar_slice_unchecked(
         scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar, InternalError> {
+    ) -> Result<Self::Scalar> {
         Ok(Scalar::from_bytes_mod_order(*scalar_bits.as_ref()))
     }
 
@@ -104,10 +104,10 @@ impl Group for RistrettoPoint {
     type ElemLen = U32;
     fn from_element_slice_unchecked(
         element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self, InternalError> {
+    ) -> Result<Self> {
         CompressedRistretto::from_slice(element_bits)
             .decompress()
-            .ok_or(InternalError::PointError)
+            .ok_or(Error::PointError)
     }
     // serialization of a group element
     fn to_arr(&self) -> GenericArray<u8, Self::ElemLen> {

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -7,8 +7,7 @@
 
 //! Includes a series of tests for the group implementations
 
-use crate::group::Group;
-use crate::{Error, Result};
+use crate::{Error, Group, Result};
 
 // Test that the deserialization of a group element should throw an error if the
 // identity element can be deserialized properly

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -7,14 +7,14 @@
 
 //! Includes a series of tests for the group implementations
 
-use crate::errors::InternalError;
 use crate::group::Group;
+use crate::{Error, Result};
 
 // Test that the deserialization of a group element should throw an error if the
 // identity element can be deserialized properly
 
 #[test]
-fn test_group_properties() -> Result<(), InternalError> {
+fn test_group_properties() -> Result<()> {
     #[cfg(feature = "ristretto255")]
     {
         use curve25519_dalek::ristretto::RistrettoPoint;
@@ -35,19 +35,19 @@ fn test_group_properties() -> Result<(), InternalError> {
 }
 
 // Checks that the identity element cannot be deserialized
-fn test_identity_element_error<G: Group>() -> Result<(), InternalError> {
+fn test_identity_element_error<G: Group>() -> Result<()> {
     let identity = G::identity();
     let result = G::from_element_slice(&identity.to_arr());
-    assert!(matches!(result, Err(InternalError::PointError)));
+    assert!(matches!(result, Err(Error::PointError)));
 
     Ok(())
 }
 
 // Checks that the zero scalar cannot be deserialized
-fn test_zero_scalar_error<G: Group>() -> Result<(), InternalError> {
+fn test_zero_scalar_error<G: Group>() -> Result<()> {
     let zero_scalar = G::scalar_zero();
     let result = G::from_scalar_slice(&G::scalar_as_bytes(zero_scalar));
-    assert!(matches!(result, Err(InternalError::ZeroScalarError)));
+    assert!(matches!(result, Err(Error::ZeroScalarError)));
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,8 +472,8 @@
 //!   VOPRF evaluations.
 //!
 //! - The `p256` feature enables using p256 as the underlying group for the
-//!   [Group] choice. Note that this is currently an experimental feature ⚠️, and
-//!   is not yet ready for production use.
+//!   [Group] choice and increases the MSRV to 1.56. Note that this is currently
+//!   an experimental feature ⚠️, and is not yet ready for production use.
 //!
 //! - The `serde` feature, enabled by default, provides convenience functions
 //!   for serializing and deserializing with [serde](https://serde.rs/).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,7 +512,7 @@ extern crate std;
 mod util;
 #[macro_use]
 mod serialization;
-pub mod errors;
+mod error;
 pub mod group;
 mod voprf;
 
@@ -521,6 +521,7 @@ mod tests;
 
 // Exports
 
+pub use crate::error::{Error, Result};
 pub use crate::voprf::{
     BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableClientBlindResult,
     NonVerifiableServer, NonVerifiableServerEvaluateResult, VerifiableClient,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,8 +472,8 @@
 //!   VOPRF evaluations.
 //!
 //! - The `p256` feature enables using p256 as the underlying group for the
-//!   [Group](group::Group) choice. Note that this is currently an experimental
-//!   feature ⚠️, and is not yet ready for production use.
+//!   [Group] choice. Note that this is currently an experimental feature ⚠️, and
+//!   is not yet ready for production use.
 //!
 //! - The `serde` feature, enabled by default, provides convenience functions
 //!   for serializing and deserializing with [serde](https://serde.rs/).
@@ -513,7 +513,7 @@ mod util;
 #[macro_use]
 mod serialization;
 mod error;
-pub mod group;
+mod group;
 mod voprf;
 
 #[cfg(test)]
@@ -522,8 +522,12 @@ mod tests;
 // Exports
 
 pub use crate::error::{Error, Result};
+pub use crate::group::Group;
+#[cfg(feature = "alloc")]
+pub use crate::voprf::VerifiableServerBatchEvaluateResult;
 pub use crate::voprf::{
     BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableClientBlindResult,
-    NonVerifiableServer, NonVerifiableServerEvaluateResult, VerifiableClient,
-    VerifiableClientBlindResult, VerifiableServer, VerifiableServerEvaluateResult,
+    NonVerifiableServer, NonVerifiableServerEvaluateResult, Proof, VerifiableClient,
+    VerifiableClientBatchFinalizeResult, VerifiableClientBlindResult, VerifiableServer,
+    VerifiableServerEvaluateResult,
 };

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -17,13 +17,13 @@ use generic_array::sequence::Concat;
 use generic_array::typenum::Sum;
 use generic_array::{ArrayLength, GenericArray};
 
-use crate::errors::InternalError;
 use crate::group::Group;
 use crate::util::deserialize;
 use crate::voprf::{
     BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableServer, Proof,
     VerifiableClient, VerifiableServer,
 };
+use crate::Result;
 
 //////////////////////////////////////////////////////////
 // Serialization and Deserialization for High-Level API //
@@ -37,7 +37,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableClient
     }
 
     /// Deserialization from bytes
-    pub fn deserialize(input: &[u8]) -> Result<Self, InternalError> {
+    pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
         let blind = G::from_scalar_slice(&deserialize(&mut input)?)?;
@@ -60,7 +60,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
     }
 
     /// Deserialization from bytes
-    pub fn deserialize(input: &[u8]) -> Result<Self, InternalError> {
+    pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
         let blind = G::from_scalar_slice(&deserialize(&mut input)?)?;
@@ -81,7 +81,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer
     }
 
     /// Deserialization from bytes
-    pub fn deserialize(input: &[u8]) -> Result<Self, InternalError> {
+    pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
         let sk = G::from_scalar_slice(&deserialize(&mut input)?)?;
@@ -104,7 +104,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
     }
 
     /// Deserialization from bytes
-    pub fn deserialize(input: &[u8]) -> Result<Self, InternalError> {
+    pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
         let sk = G::from_scalar_slice(&deserialize(&mut input)?)?;
@@ -129,7 +129,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> Proof<G, H> {
     }
 
     /// Deserialization from bytes
-    pub fn deserialize(input: &[u8]) -> Result<Self, InternalError> {
+    pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
         let c_scalar = G::from_scalar_slice(&deserialize(&mut input)?)?;
@@ -150,7 +150,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H
     }
 
     /// Deserialization from bytes
-    pub fn deserialize(input: &[u8]) -> Result<Self, InternalError> {
+    pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
         let value = G::from_element_slice(&deserialize(&mut input)?)?;
@@ -169,7 +169,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> EvaluationElement<G
     }
 
     /// Deserialization from bytes
-    pub fn deserialize(input: &[u8]) -> Result<Self, InternalError> {
+    pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
         let value = G::from_element_slice(&deserialize(&mut input)?)?;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -17,13 +17,11 @@ use generic_array::sequence::Concat;
 use generic_array::typenum::Sum;
 use generic_array::{ArrayLength, GenericArray};
 
-use crate::group::Group;
 use crate::util::deserialize;
-use crate::voprf::{
-    BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableServer, Proof,
-    VerifiableClient, VerifiableServer,
+use crate::{
+    BlindedElement, EvaluationElement, Group, NonVerifiableClient, NonVerifiableServer, Proof,
+    Result, VerifiableClient, VerifiableServer,
 };
-use crate::Result;
 
 //////////////////////////////////////////////////////////
 // Serialization and Deserialization for High-Level API //

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -17,10 +17,9 @@ use generic_array::sequence::Concat;
 use generic_array::typenum::Sum;
 use generic_array::{ArrayLength, GenericArray};
 
-use crate::util::deserialize;
 use crate::{
-    BlindedElement, EvaluationElement, Group, NonVerifiableClient, NonVerifiableServer, Proof,
-    Result, VerifiableClient, VerifiableServer,
+    BlindedElement, Error, EvaluationElement, Group, NonVerifiableClient, NonVerifiableServer,
+    Proof, Result, VerifiableClient, VerifiableServer,
 };
 
 //////////////////////////////////////////////////////////
@@ -177,4 +176,11 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> EvaluationElement<G
             hash: PhantomData,
         })
     }
+}
+
+fn deserialize<L: ArrayLength<u8>>(
+    input: &mut impl Iterator<Item = u8>,
+) -> Result<GenericArray<u8, L>> {
+    let input = input.by_ref().take(L::USIZE);
+    GenericArray::from_exact_iter(input).ok_or(Error::SizeError)
 }

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -19,7 +19,6 @@ use ::{
     generic_array::{typenum::Sum, ArrayLength},
 };
 
-use crate::errors::InternalError;
 use crate::group::Group;
 #[cfg(feature = "alloc")]
 use crate::tests::mock_rng::CycleRng;
@@ -28,6 +27,7 @@ use crate::voprf::{
     BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableServer, Proof,
     VerifiableClient, VerifiableServer,
 };
+use crate::Result;
 
 #[derive(Debug)]
 struct VOPRFTestVectorParameters {
@@ -92,7 +92,7 @@ macro_rules! json_to_test_vectors {
 }
 
 #[test]
-fn test_vectors() -> Result<(), InternalError> {
+fn test_vectors() -> Result<()> {
     let rfc = json::parse(rfc_to_json(super::voprf_vectors::VECTORS).as_str())
         .expect("Could not parse json");
 
@@ -155,7 +155,7 @@ fn test_vectors() -> Result<(), InternalError> {
 
 fn test_base_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError> {
+) -> Result<()> {
     for parameters in tvs {
         let server = NonVerifiableServer::<G, H>::new_from_seed(&parameters.seed)?;
 
@@ -169,7 +169,7 @@ fn test_base_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>
 
 fn test_verifiable_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError> {
+) -> Result<()> {
     for parameters in tvs {
         let server = VerifiableServer::<G, H>::new_from_seed(&parameters.seed)?;
 
@@ -185,7 +185,7 @@ fn test_verifiable_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutput
 // Tests input -> blind, blinded_element
 fn test_base_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError> {
+) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let blind =
@@ -211,7 +211,7 @@ fn test_base_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 // Tests input -> blind, blinded_element
 fn test_verifiable_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError> {
+) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let blind =
@@ -237,7 +237,7 @@ fn test_verifiable_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>
 // Tests sksm, blinded_element -> evaluation_element
 fn test_base_evaluate<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError> {
+) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let server = NonVerifiableServer::<G, H>::new_with_key(&parameters.sksm)?;
@@ -258,7 +258,7 @@ fn test_base_evaluate<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 #[cfg(feature = "alloc")]
 fn test_verifiable_evaluate<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError>
+) -> Result<()>
 where
     G::ScalarLen: Add<G::ScalarLen>,
     Sum<G::ScalarLen, G::ScalarLen>: ArrayLength<u8>,
@@ -293,7 +293,7 @@ where
 // Tests input, blind, evaluation_element -> output
 fn test_base_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError> {
+) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let client = NonVerifiableClient::<G, H>::from_blind(G::from_scalar_slice(
@@ -314,7 +314,7 @@ fn test_base_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 
 fn test_verifiable_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     tvs: &[VOPRFTestVectorParameters],
-) -> Result<(), InternalError> {
+) -> Result<()> {
     for parameters in tvs {
         let mut clients = vec![];
         for i in 0..parameters.input.len() {
@@ -346,7 +346,7 @@ fn test_verifiable_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputRes
             parameters.output,
             batch_result
                 .map(|arr| arr.map(|message| message.to_vec()))
-                .collect::<Result<Vec<_>, _>>()?
+                .collect::<Result<Vec<_>>>()?
         );
     }
     Ok(())

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -19,15 +19,13 @@ use ::{
     generic_array::{typenum::Sum, ArrayLength},
 };
 
-use crate::group::Group;
 #[cfg(feature = "alloc")]
 use crate::tests::mock_rng::CycleRng;
 use crate::tests::parser::*;
-use crate::voprf::{
-    BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableServer, Proof,
-    VerifiableClient, VerifiableServer,
+use crate::{
+    BlindedElement, EvaluationElement, Group, NonVerifiableClient, NonVerifiableServer, Proof,
+    Result, VerifiableClient, VerifiableServer,
 };
-use crate::Result;
 
 #[derive(Debug)]
 struct VOPRFTestVectorParameters {

--- a/src/util.rs
+++ b/src/util.rs
@@ -131,7 +131,7 @@ mod unit_tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::voprf::{
+    use crate::{
         BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableServer, Proof,
         VerifiableClient, VerifiableServer,
     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -81,13 +81,6 @@ pub(crate) fn serialize_owned<L1: ArrayLength<u8>, L2: ArrayLength<u8>>(
     })
 }
 
-pub(crate) fn deserialize<L: ArrayLength<u8>>(
-    input: &mut impl Iterator<Item = u8>,
-) -> Result<GenericArray<u8, L>> {
-    let input = input.by_ref().take(L::USIZE);
-    GenericArray::from_exact_iter(input).ok_or(Error::SizeError)
-}
-
 macro_rules! chain_name {
     ($var:ident, $mod:ident) => {
         $mod

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -22,9 +22,9 @@ use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeEq;
 
-use crate::errors::InternalError;
 use crate::group::Group;
 use crate::util::{i2osp, serialize, serialize_owned};
+use crate::{Error, Result};
 
 ///////////////
 // Constants //
@@ -199,7 +199,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableClient
     pub fn blind<R: RngCore + CryptoRng>(
         input: &[u8],
         blinding_factor_rng: &mut R,
-    ) -> Result<NonVerifiableClientBlindResult<G, H>, InternalError> {
+    ) -> Result<NonVerifiableClientBlindResult<G, H>> {
         let (blind, blinded_element) = blind::<G, H, _>(input, blinding_factor_rng, Mode::Base)?;
         Ok(NonVerifiableClientBlindResult {
             state: Self {
@@ -225,7 +225,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableClient
     pub fn deterministic_blind_unchecked(
         input: &[u8],
         blind: G::Scalar,
-    ) -> Result<NonVerifiableClientBlindResult<G, H>, InternalError> {
+    ) -> Result<NonVerifiableClientBlindResult<G, H>> {
         let blinded_element = deterministic_blind_unchecked::<G, H>(input, &blind, Mode::Base)?;
         Ok(NonVerifiableClientBlindResult {
             state: Self {
@@ -246,7 +246,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableClient
         input: &[u8],
         evaluation_element: &EvaluationElement<G, H>,
         metadata: Option<&[u8]>,
-    ) -> Result<GenericArray<u8, H::OutputSize>, InternalError> {
+    ) -> Result<GenericArray<u8, H::OutputSize>> {
         let unblinded_element = evaluation_element.value * &G::scalar_invert(&self.blind);
         let mut outputs = finalize_after_unblind::<G, H, _, _>(
             Some((input, unblinded_element)).into_iter(),
@@ -278,7 +278,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
     pub fn blind<R: RngCore + CryptoRng>(
         input: &[u8],
         blinding_factor_rng: &mut R,
-    ) -> Result<VerifiableClientBlindResult<G, H>, InternalError> {
+    ) -> Result<VerifiableClientBlindResult<G, H>> {
         let (blind, blinded_element) =
             blind::<G, H, _>(input, blinding_factor_rng, Mode::Verifiable)?;
         Ok(VerifiableClientBlindResult {
@@ -306,7 +306,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
     pub fn deterministic_blind_unchecked(
         input: &[u8],
         blind: G::Scalar,
-    ) -> Result<VerifiableClientBlindResult<G, H>, InternalError> {
+    ) -> Result<VerifiableClientBlindResult<G, H>> {
         let blinded_element =
             deterministic_blind_unchecked::<G, H>(input, &blind, Mode::Verifiable)?;
         Ok(VerifiableClientBlindResult {
@@ -331,7 +331,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         proof: &Proof<G, H>,
         pk: G,
         metadata: Option<&[u8]>,
-    ) -> Result<GenericArray<u8, H::OutputSize>, InternalError> {
+    ) -> Result<GenericArray<u8, H::OutputSize>> {
         // `core::array::from_ref` needs a MSRV of 1.53
         let inputs: &[&[u8]; 1] = core::slice::from_ref(&input).try_into().unwrap();
         let clients: &[Self; 1] = core::slice::from_ref(self).try_into().unwrap();
@@ -353,7 +353,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         proof: &Proof<G, H>,
         pk: G,
         metadata: Option<&'a [u8]>,
-    ) -> Result<VerifiableClientBatchFinalizeResult<'a, G, H, I, II, IC, IM>, InternalError>
+    ) -> Result<VerifiableClientBatchFinalizeResult<'a, G, H, I, II, IC, IM>>
     where
         G: 'a,
         H: 'a,
@@ -397,7 +397,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
 
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer<G, H> {
     /// Produces a new instance of a [NonVerifiableServer] using a supplied RNG
-    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self, InternalError> {
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self> {
         let mut seed = GenericArray::<_, H::OutputSize>::default();
         rng.fill_bytes(&mut seed);
         Self::new_from_seed(&seed)
@@ -405,7 +405,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer
 
     /// Produces a new instance of a [NonVerifiableServer] using a supplied set
     /// of bytes to represent the server's private key
-    pub fn new_with_key(private_key_bytes: &[u8]) -> Result<Self, InternalError> {
+    pub fn new_with_key(private_key_bytes: &[u8]) -> Result<Self> {
         let sk = G::from_scalar_slice(private_key_bytes)?;
         Ok(Self {
             sk,
@@ -417,7 +417,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer
     /// of bytes which are used as a seed to derive the server's private key.
     ///
     /// Corresponds to DeriveKeyPair() function from the VOPRF specification.
-    pub fn new_from_seed(seed: &[u8]) -> Result<Self, InternalError> {
+    pub fn new_from_seed(seed: &[u8]) -> Result<Self> {
         let dst =
             GenericArray::from(STR_HASH_TO_SCALAR).concat(get_context_string::<G>(Mode::Base)?);
         let sk = G::hash_to_scalar::<H, _, _>(Some(seed), dst)?;
@@ -440,7 +440,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer
         &self,
         blinded_element: &BlindedElement<G, H>,
         metadata: Option<&[u8]>,
-    ) -> Result<NonVerifiableServerEvaluateResult<G, H>, InternalError> {
+    ) -> Result<NonVerifiableServerEvaluateResult<G, H>> {
         chain!(
             context,
             STR_CONTEXT => |x| Some(x.as_ref()),
@@ -463,7 +463,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer
 
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G, H> {
     /// Produces a new instance of a [VerifiableServer] using a supplied RNG
-    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self, InternalError> {
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self> {
         let mut seed = GenericArray::<_, H::OutputSize>::default();
         rng.fill_bytes(&mut seed);
         Self::new_from_seed(&seed)
@@ -471,7 +471,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
 
     /// Produces a new instance of a [VerifiableServer] using a supplied set of
     /// bytes to represent the server's private key
-    pub fn new_with_key(key: &[u8]) -> Result<Self, InternalError> {
+    pub fn new_with_key(key: &[u8]) -> Result<Self> {
         let sk = G::from_scalar_slice(key)?;
         let pk = G::base_point() * &sk;
         Ok(Self {
@@ -485,7 +485,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
     /// bytes which are used as a seed to derive the server's private key.
     ///
     /// Corresponds to DeriveKeyPair() function from the VOPRF specification.
-    pub fn new_from_seed(seed: &[u8]) -> Result<Self, InternalError> {
+    pub fn new_from_seed(seed: &[u8]) -> Result<Self> {
         let dst = GenericArray::from(STR_HASH_TO_SCALAR)
             .concat(get_context_string::<G>(Mode::Verifiable)?);
         let sk = G::hash_to_scalar::<H, _, _>(Some(seed), dst)?;
@@ -511,7 +511,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         rng: &mut R,
         blinded_element: &BlindedElement<G, H>,
         metadata: Option<&[u8]>,
-    ) -> Result<VerifiableServerEvaluateResult<G, H>, InternalError> {
+    ) -> Result<VerifiableServerEvaluateResult<G, H>> {
         let (mut evaluation_elements, t) =
             self.batch_evaluate_1(Some(blinded_element.copy()).into_iter(), metadata)?;
 
@@ -539,7 +539,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         rng: &mut R,
         blinded_elements: &'a I,
         metadata: Option<&[u8]>,
-    ) -> Result<VerifiableServerBatchEvaluateResult<G, H>, InternalError>
+    ) -> Result<VerifiableServerBatchEvaluateResult<G, H>>
     where
         G: 'a,
         H: 'a,
@@ -570,13 +570,10 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         &self,
         blinded_elements: I,
         metadata: Option<&[u8]>,
-    ) -> Result<
-        (
-            impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
-            G::Scalar,
-        ),
-        InternalError,
-    >
+    ) -> Result<(
+        impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
+        G::Scalar,
+    )>
     where
         I: Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
     {
@@ -604,7 +601,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         blinded_elements: IB,
         evaluation_elements: IE,
         t: G::Scalar,
-    ) -> Result<Proof<G, H>, InternalError>
+    ) -> Result<Proof<G, H>>
     where
         IB: Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
         IE: Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
@@ -747,7 +744,7 @@ fn blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset, R: RngCore + Cr
     input: &[u8],
     blinding_factor_rng: &mut R,
     mode: Mode,
-) -> Result<(G::Scalar, G), InternalError> {
+) -> Result<(G::Scalar, G)> {
     // Choose a random scalar that must be non-zero
     let blind = G::random_nonzero_scalar(blinding_factor_rng);
     let blinded_element = deterministic_blind_unchecked::<G, H>(input, &blind, mode)?;
@@ -761,7 +758,7 @@ fn deterministic_blind_unchecked<G: Group, H: BlockSizeUser + Digest + FixedOutp
     input: &[u8],
     blind: &G::Scalar,
     mode: Mode,
-) -> Result<G, InternalError> {
+) -> Result<G> {
     let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(get_context_string::<G>(mode)?);
     let hashed_point = G::hash_to_curve::<H, _>(input, dst)?;
     Ok(hashed_point * blind)
@@ -788,7 +785,7 @@ fn verifiable_unblind<
     pk: G,
     proof: &Proof<G, H>,
     info: &[u8],
-) -> Result<VerifiableUnblindResult<'a, G, H, IC, IM>, InternalError>
+) -> Result<VerifiableUnblindResult<'a, G, H, IC, IM>>
 where
     &'a IC: 'a + IntoIterator<Item = &'a VerifiableClient<G, H>>,
     <&'a IC as IntoIterator>::IntoIter: ExactSizeIterator,
@@ -838,7 +835,7 @@ fn generate_proof<
     b: G,
     cs: impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
     ds: impl Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
-) -> Result<Proof<G, H>, InternalError> {
+) -> Result<Proof<G, H>> {
     let (m, z) = compute_composites(Some(k), b, cs, ds)?;
 
     let r = G::random_nonzero_scalar(rng);
@@ -877,7 +874,7 @@ fn verify_proof<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     cs: impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
     ds: impl Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
     proof: &Proof<G, H>,
-) -> Result<(), InternalError> {
+) -> Result<()> {
     let (m, z) = compute_composites(None, b, cs, ds)?;
     let t2 = (a * &proof.s_scalar) + &(b * &proof.c_scalar);
     let t3 = (m * &proof.s_scalar) + &(z * &proof.c_scalar);
@@ -900,16 +897,14 @@ fn verify_proof<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 
     match c.ct_eq(&proof.c_scalar).into() {
         true => Ok(()),
-        false => Err(InternalError::ProofVerificationError),
+        false => Err(Error::ProofVerificationError),
     }
 }
 
 #[allow(type_alias_bounds)]
 type FinalizeAfterUnblindResult<'a, G, H: Digest, I, IE> = Map<
     Zip<IE, Repeat<(&'a [u8], GenericArray<u8, U20>)>>,
-    fn(
-        ((I, G), (&'a [u8], GenericArray<u8, U20>)),
-    ) -> Result<GenericArray<u8, H::OutputSize>, InternalError>,
+    fn(((I, G), (&'a [u8], GenericArray<u8, U20>))) -> Result<GenericArray<u8, H::OutputSize>>,
 >;
 
 fn finalize_after_unblind<
@@ -922,7 +917,7 @@ fn finalize_after_unblind<
     inputs_and_unblinded_elements: IE,
     info: &'a [u8],
     mode: Mode,
-) -> Result<FinalizeAfterUnblindResult<G, H, I, IE>, InternalError> {
+) -> Result<FinalizeAfterUnblindResult<G, H, I, IE>> {
     let finalize_dst = GenericArray::from(STR_FINALIZE).concat(get_context_string::<G>(mode)?);
 
     Ok(inputs_and_unblinded_elements
@@ -949,9 +944,9 @@ fn compute_composites<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     b: G,
     c_slice: impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
     d_slice: impl Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
-) -> Result<(G, G), InternalError> {
+) -> Result<(G, G)> {
     if c_slice.len() != d_slice.len() {
-        return Err(InternalError::MismatchedLengthsForCompositeInputs);
+        return Err(Error::MismatchedLengthsForCompositeInputs);
     }
 
     let seed_dst = GenericArray::from(STR_SEED).concat(get_context_string::<G>(Mode::Verifiable)?);
@@ -998,7 +993,7 @@ fn compute_composites<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 
 /// Generates the contextString parameter as defined in
 /// <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html>
-fn get_context_string<G: Group>(mode: Mode) -> Result<GenericArray<u8, U11>, InternalError> {
+fn get_context_string<G: Group>(mode: Mode) -> Result<GenericArray<u8, U11>> {
     Ok(GenericArray::from(STR_VOPRF)
         .concat(i2osp::<U1>(mode as usize)?)
         .concat(i2osp::<U2>(G::SUITE_ID)?))
@@ -1145,7 +1140,7 @@ mod tests {
             Some(info),
         )
         .unwrap()
-        .collect::<Result<Vec<_>, _>>()
+        .collect::<Result<Vec<_>>>()
         .unwrap();
         let mut res2 = vec![];
         for input in inputs.iter().take(num_iterations) {
@@ -1305,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_functionality() -> Result<(), InternalError> {
+    fn test_functionality() -> Result<()> {
         #[cfg(feature = "ristretto255")]
         {
             use curve25519_dalek::ristretto::RistrettoPoint;

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -22,9 +22,8 @@ use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeEq;
 
-use crate::group::Group;
 use crate::util::{i2osp, serialize, serialize_owned};
-use crate::{Error, Result};
+use crate::{Error, Group, Result};
 
 ///////////////
 // Constants //
@@ -646,6 +645,7 @@ pub struct VerifiableClientBlindResult<G: Group, H: BlockSizeUser + Digest + Fix
     pub message: BlindedElement<G, H>,
 }
 
+/// Concrete return type for [`VerifiableClient::batch_finalize`].
 pub type VerifiableClientBatchFinalizeResult<'a, G, H, I, II, IC, IM> = FinalizeAfterUnblindResult<
     'a,
     G,
@@ -1016,7 +1016,7 @@ mod tests {
     use ::{alloc::vec, alloc::vec::Vec};
 
     use super::*;
-    use crate::group::Group;
+    use crate::Group;
 
     fn prf<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
         input: &[u8],


### PR DESCRIPTION
- Add a `Result` shorthand: `Result<T, InternalError`.
- Rename `InternalError` to `Error`, I believe this was an artifact when we still had multiple error types.
- Re-export `Group`, `Result`, `Error`, `VerifiableClientBatchFinalizeResult` and `VerifiableServerBatchEvaluateResult`.
- Made `group` and `error` modules private, because of re-exports.
- Re-export `Proof`, this was kinda a bug because downstream users couldn't use that type, strange that Rust didn't complain.
- Move `deserialize` to the `serialize` module, the only place it was used.
- Make `serialize` and `serialize_owned` to methods of `Serialized`, which was renamed to `Serialize`.
- Update p256 to 0.10.