### PR TITLE
Reduce version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "voprf"
 readme = "README.md"
 repository = "https://github.com/novifinancial/voprf/"
 resolver = "2"
-rust-version = "1.51.0"
+rust-version = "1.51"
 version = "0.3.0"
 
 [features]


### PR DESCRIPTION
Just recently learned this is possible. I don't believe there is a difference, but it seems to be more common and whats "recommended": https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field.