### PR TITLE
`Group` trait overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ p256 = [
   "once_cell",
   "p256_",
 ]
-ristretto255 = []
+ristretto255 = ["generic-array/more_lengths"]
 ristretto255_fiat_u32 = ["curve25519-dalek/fiat_u32_backend", "ristretto255"]
 ristretto255_fiat_u64 = ["curve25519-dalek/fiat_u64_backend", "ristretto255"]
 ristretto255_simd = ["curve25519-dalek/simd_backend", "ristretto255"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,8 +34,8 @@ pub enum Error {
     ProofVerificationError,
     /// Encountered insufficient bytes when attempting to deserialize
     SizeError,
-    /// Encountered a zero scalar
-    ZeroScalarError,
+    /// Encountered an invalid scalar
+    ScalarError,
 }
 
 #[cfg(feature = "std")]

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -83,13 +83,13 @@ pub trait Group {
     fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar>;
 
     /// picks a scalar at random
-    fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;
+    fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;
 
     /// Serializes a scalar to bytes
-    fn scalar_as_bytes(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen>;
+    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen>;
 
     /// The multiplicative inverse of this scalar
-    fn scalar_invert(scalar: &Self::Scalar) -> Self::Scalar;
+    fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar;
 
     /// Return an element from its fixed-length bytes representation. This is
     /// the unchecked version, which does not check for deserializing the

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -78,35 +78,35 @@ pub trait Group {
     where
         <D as Add<U1>>::Output: ArrayLength<u8>;
 
-    /// Return a scalar from its fixed-length bytes representation. If the
-    /// scalar is zero or invalid, then return an error.
-    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar>;
-
-    /// picks a scalar at random
-    fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;
-
-    /// Serializes a scalar to bytes
-    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen>;
-
-    /// The multiplicative inverse of this scalar
-    fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar;
-
-    /// Return an element from its fixed-length bytes representation. If the
-    /// element is the identity element, return an error.
-    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem>;
-
-    /// Serializes the `self` group element
-    fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen>;
-
     /// Get the base point for the group
     fn base_elem() -> Self::Elem;
 
     /// Returns the identity group element
     fn identity_elem() -> Self::Elem;
 
+    /// Serializes the `self` group element
+    fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen>;
+
+    /// Return an element from its fixed-length bytes representation. If the
+    /// element is the identity element, return an error.
+    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem>;
+
+    /// picks a scalar at random
+    fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;
+
+    /// The multiplicative inverse of this scalar
+    fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar;
+
     /// Returns the scalar representing zero
     #[cfg(test)]
     fn zero_scalar() -> Self::Scalar;
+
+    /// Serializes a scalar to bytes
+    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen>;
+
+    /// Return a scalar from its fixed-length bytes representation. If the
+    /// scalar is zero or invalid, then return an error.
+    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar>;
 }
 
 #[cfg(test)]

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -78,23 +78,9 @@ pub trait Group {
     where
         <D as Add<U1>>::Output: ArrayLength<u8>;
 
-    /// Return a scalar from its fixed-length bytes representation, without
-    /// checking if the scalar is zero.
-    fn from_scalar_slice_unchecked(
-        scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar>;
-
     /// Return a scalar from its fixed-length bytes representation. If the
-    /// scalar is zero, then return an error.
-    fn from_scalar_slice<'a>(
-        scalar_bits: impl Into<&'a GenericArray<u8, Self::ScalarLen>>,
-    ) -> Result<Self::Scalar> {
-        let scalar = Self::from_scalar_slice_unchecked(scalar_bits.into())?;
-        if scalar.ct_eq(&Self::scalar_zero()).into() {
-            return Err(Error::ZeroScalarError);
-        }
-        Ok(scalar)
-    }
+    /// scalar is zero or invalid, then return an error.
+    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar>;
 
     /// picks a scalar at random
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -33,7 +33,7 @@ use crate::{Error, Result};
 pub trait Group {
     /// The ciphersuite identifier as dictated by
     /// <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-05.txt>
-    const SUITE_ID: usize;
+    const SUITE_ID: u16;
 
     /// The type of group elements
     type Elem: Copy

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -26,7 +26,7 @@ pub use ristretto::Ristretto255;
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
-use crate::{Error, Result};
+use crate::Result;
 
 /// A prime-order subgroup of a base field (EC, prime-order field ...). This
 /// subgroup is noted additively — as in the draft RFC — in this trait.
@@ -91,27 +91,9 @@ pub trait Group {
     /// The multiplicative inverse of this scalar
     fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar;
 
-    /// Return an element from its fixed-length bytes representation. This is
-    /// the unchecked version, which does not check for deserializing the
-    /// identity element
-    fn from_element_slice_unchecked(
-        element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self::Elem>;
-
     /// Return an element from its fixed-length bytes representation. If the
     /// element is the identity element, return an error.
-    fn from_element_slice<'a>(
-        element_bits: impl Into<&'a GenericArray<u8, Self::ElemLen>>,
-    ) -> Result<Self::Elem> {
-        let elem = Self::from_element_slice_unchecked(element_bits.into())?;
-
-        if Self::Elem::ct_eq(&elem, &Self::identity()).into() {
-            // found the identity element
-            return Err(Error::PointError);
-        }
-
-        Ok(elem)
-    }
+    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem>;
 
     /// Serializes the `self` group element
     fn to_arr(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen>;

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -96,21 +96,17 @@ pub trait Group {
     fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem>;
 
     /// Serializes the `self` group element
-    fn to_arr(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen>;
+    fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen>;
 
     /// Get the base point for the group
-    fn base_point() -> Self::Elem;
-
-    /// Returns if the group element is equal to the identity (1)
-    fn is_identity(elem: Self::Elem) -> bool {
-        elem.ct_eq(&Self::identity()).into()
-    }
+    fn base_elem() -> Self::Elem;
 
     /// Returns the identity group element
-    fn identity() -> Self::Elem;
+    fn identity_elem() -> Self::Elem;
 
     /// Returns the scalar representing zero
-    fn scalar_zero() -> Self::Scalar;
+    #[cfg(test)]
+    fn zero_scalar() -> Self::Scalar;
 }
 
 #[cfg(test)]

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -21,6 +21,8 @@ use digest::{Digest, FixedOutputReset};
 use generic_array::typenum::U1;
 use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "ristretto255")]
+pub use ristretto::Ristretto255;
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
@@ -28,22 +30,38 @@ use crate::{Error, Result};
 
 /// A prime-order subgroup of a base field (EC, prime-order field ...). This
 /// subgroup is noted additively — as in the draft RFC — in this trait.
-pub trait Group:
-    Copy
-    + Sized
-    + ConstantTimeEq
-    + for<'a> Mul<&'a <Self as Group>::Scalar, Output = Self>
-    + for<'a> Add<&'a Self, Output = Self>
-{
+pub trait Group {
     /// The ciphersuite identifier as dictated by
     /// <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-05.txt>
     const SUITE_ID: usize;
+
+    /// The type of group elements
+    type Elem: Copy
+        + Sized
+        + ConstantTimeEq
+        + Zeroize
+        + for<'a> Mul<&'a Self::Scalar, Output = Self::Elem>
+        + for<'a> Add<&'a Self::Elem, Output = Self::Elem>;
+
+    /// The byte length necessary to represent group elements
+    type ElemLen: ArrayLength<u8> + 'static;
+
+    /// The type of base field scalars
+    type Scalar: Zeroize
+        + Copy
+        + ConstantTimeEq
+        + for<'a> Add<&'a Self::Scalar, Output = Self::Scalar>
+        + for<'a> Sub<&'a Self::Scalar, Output = Self::Scalar>
+        + for<'a> Mul<&'a Self::Scalar, Output = Self::Scalar>;
+
+    /// The byte length necessary to represent scalars
+    type ScalarLen: ArrayLength<u8> + 'static;
 
     /// transforms a password and domain separation tag (DST) into a curve point
     fn hash_to_curve<H: BlockSizeUser + Digest + FixedOutputReset, D: ArrayLength<u8> + Add<U1>>(
         msg: &[u8],
         dst: GenericArray<u8, D>,
-    ) -> Result<Self>
+    ) -> Result<Self::Elem>
     where
         <D as Add<U1>>::Output: ArrayLength<u8>;
 
@@ -59,16 +77,6 @@ pub trait Group:
     ) -> Result<Self::Scalar>
     where
         <D as Add<U1>>::Output: ArrayLength<u8>;
-
-    /// The type of base field scalars
-    type Scalar: Zeroize
-        + Copy
-        + ConstantTimeEq
-        + for<'a> Add<&'a Self::Scalar, Output = Self::Scalar>
-        + for<'a> Sub<&'a Self::Scalar, Output = Self::Scalar>
-        + for<'a> Mul<&'a Self::Scalar, Output = Self::Scalar>;
-    /// The byte length necessary to represent scalars
-    type ScalarLen: ArrayLength<u8> + 'static;
 
     /// Return a scalar from its fixed-length bytes representation, without
     /// checking if the scalar is zero.
@@ -90,28 +98,28 @@ pub trait Group:
 
     /// picks a scalar at random
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;
+
     /// Serializes a scalar to bytes
     fn scalar_as_bytes(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen>;
+
     /// The multiplicative inverse of this scalar
     fn scalar_invert(scalar: &Self::Scalar) -> Self::Scalar;
-
-    /// The byte length necessary to represent group elements
-    type ElemLen: ArrayLength<u8> + 'static;
 
     /// Return an element from its fixed-length bytes representation. This is
     /// the unchecked version, which does not check for deserializing the
     /// identity element
-    fn from_element_slice_unchecked(element_bits: &GenericArray<u8, Self::ElemLen>)
-        -> Result<Self>;
+    fn from_element_slice_unchecked(
+        element_bits: &GenericArray<u8, Self::ElemLen>,
+    ) -> Result<Self::Elem>;
 
     /// Return an element from its fixed-length bytes representation. If the
     /// element is the identity element, return an error.
     fn from_element_slice<'a>(
         element_bits: impl Into<&'a GenericArray<u8, Self::ElemLen>>,
-    ) -> Result<Self> {
+    ) -> Result<Self::Elem> {
         let elem = Self::from_element_slice_unchecked(element_bits.into())?;
 
-        if Self::ct_eq(&elem, &<Self as Group>::identity()).into() {
+        if Self::Elem::ct_eq(&elem, &Self::identity()).into() {
             // found the identity element
             return Err(Error::PointError);
         }
@@ -120,26 +128,21 @@ pub trait Group:
     }
 
     /// Serializes the `self` group element
-    fn to_arr(&self) -> GenericArray<u8, Self::ElemLen>;
+    fn to_arr(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen>;
 
     /// Get the base point for the group
-    fn base_point() -> Self;
+    fn base_point() -> Self::Elem;
 
     /// Returns if the group element is equal to the identity (1)
-    fn is_identity(&self) -> bool {
-        self.ct_eq(&<Self as Group>::identity()).into()
+    fn is_identity(elem: Self::Elem) -> bool {
+        elem.ct_eq(&Self::identity()).into()
     }
 
     /// Returns the identity group element
-    fn identity() -> Self;
+    fn identity() -> Self::Elem;
 
     /// Returns the scalar representing zero
     fn scalar_zero() -> Self::Scalar;
-
-    /// Set the contents of self to the identity value
-    fn zeroize(&mut self) {
-        *self = <Self as Group>::identity();
-    }
 }
 
 #[cfg(test)]

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -27,6 +27,7 @@ use once_cell::unsync::Lazy;
 use p256_::elliptic_curve::group::prime::PrimeCurveAffine;
 use p256_::elliptic_curve::ops::Reduce;
 use p256_::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+#[cfg(test)]
 use p256_::elliptic_curve::Field;
 use p256_::{AffinePoint, EncodedPoint, NistP256, ProjectivePoint, PublicKey, Scalar, SecretKey};
 use rand_core::{CryptoRng, RngCore};
@@ -167,7 +168,7 @@ impl Group for NistP256 {
             .map_err(|_| Error::PointError)
     }
 
-    fn to_arr(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
+    fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
         let bytes = elem.to_affine().to_encoded_point(true);
         let bytes = bytes.as_bytes();
         let mut result = GenericArray::default();
@@ -175,15 +176,16 @@ impl Group for NistP256 {
         result
     }
 
-    fn base_point() -> Self::Elem {
+    fn base_elem() -> Self::Elem {
         ProjectivePoint::generator()
     }
 
-    fn identity() -> Self::Elem {
+    fn identity_elem() -> Self::Elem {
         ProjectivePoint::identity()
     }
 
-    fn scalar_zero() -> Self::Scalar {
+    #[cfg(test)]
+    fn zero_scalar() -> Self::Scalar {
         Scalar::zero()
     }
 }

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -29,7 +29,7 @@ use p256_::elliptic_curve::group::GroupEncoding;
 use p256_::elliptic_curve::ops::Reduce;
 use p256_::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256_::elliptic_curve::Field;
-use p256_::{AffinePoint, EncodedPoint, ProjectivePoint};
+use p256_::{AffinePoint, EncodedPoint, NistP256, ProjectivePoint, Scalar};
 use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable};
 
@@ -41,15 +41,23 @@ use crate::{Error, Result};
 pub type L = U48;
 
 #[cfg(feature = "p256")]
-impl Group for ProjectivePoint {
+impl Group for NistP256 {
     const SUITE_ID: usize = 0x0003;
+
+    type Elem = ProjectivePoint;
+
+    type ElemLen = U33;
+
+    type Scalar = Scalar;
+
+    type ScalarLen = U32;
 
     // Implements the `hash_to_curve()` function from
     // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-3
     fn hash_to_curve<H: BlockSizeUser + Digest + FixedOutputReset, D: ArrayLength<u8> + Add<U1>>(
         msg: &[u8],
         dst: GenericArray<u8, D>,
-    ) -> Result<Self>
+    ) -> Result<Self::Elem>
     where
         <D as Add<U1>>::Output: ArrayLength<u8>,
     {
@@ -133,21 +141,17 @@ impl Group for ProjectivePoint {
         let mut result = GenericArray::default();
         result[..bytes.len()].copy_from_slice(&bytes);
 
-        Ok(p256_::Scalar::from_be_bytes_reduced(result))
+        Ok(Scalar::from_be_bytes_reduced(result))
     }
-
-    type ElemLen = U33;
-    type Scalar = p256_::Scalar;
-    type ScalarLen = U32;
 
     fn from_scalar_slice_unchecked(
         scalar_bits: &GenericArray<u8, Self::ScalarLen>,
     ) -> Result<Self::Scalar> {
-        Ok(Self::Scalar::from_be_bytes_reduced(*scalar_bits))
+        Ok(Scalar::from_be_bytes_reduced(*scalar_bits))
     }
 
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
-        Self::Scalar::random(rng)
+        Scalar::random(rng)
     }
 
     fn scalar_as_bytes(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
@@ -155,33 +159,33 @@ impl Group for ProjectivePoint {
     }
 
     fn scalar_invert(scalar: &Self::Scalar) -> Self::Scalar {
-        scalar.invert().unwrap_or(Self::Scalar::zero())
+        scalar.invert().unwrap_or(Scalar::zero())
     }
 
     fn from_element_slice_unchecked(
         element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self> {
-        Option::from(Self::from_bytes(element_bits)).ok_or(Error::PointError)
+    ) -> Result<Self::Elem> {
+        Option::from(ProjectivePoint::from_bytes(element_bits)).ok_or(Error::PointError)
     }
 
-    fn to_arr(&self) -> GenericArray<u8, Self::ElemLen> {
-        let bytes = self.to_affine().to_encoded_point(true);
+    fn to_arr(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
+        let bytes = elem.to_affine().to_encoded_point(true);
         let bytes = bytes.as_bytes();
         let mut result = GenericArray::default();
         result[..bytes.len()].copy_from_slice(bytes);
         result
     }
 
-    fn base_point() -> Self {
-        Self::generator()
+    fn base_point() -> Self::Elem {
+        ProjectivePoint::generator()
     }
 
-    fn identity() -> Self {
-        Self::identity()
+    fn identity() -> Self::Elem {
+        ProjectivePoint::identity()
     }
 
     fn scalar_zero() -> Self::Scalar {
-        Self::Scalar::zero()
+        Scalar::zero()
     }
 }
 

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -25,11 +25,10 @@ use num_integer::Integer;
 use num_traits::{One, ToPrimitive, Zero};
 use once_cell::unsync::Lazy;
 use p256_::elliptic_curve::group::prime::PrimeCurveAffine;
-use p256_::elliptic_curve::group::GroupEncoding;
 use p256_::elliptic_curve::ops::Reduce;
 use p256_::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256_::elliptic_curve::Field;
-use p256_::{AffinePoint, EncodedPoint, NistP256, ProjectivePoint, Scalar, SecretKey};
+use p256_::{AffinePoint, EncodedPoint, NistP256, ProjectivePoint, PublicKey, Scalar, SecretKey};
 use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable};
 
@@ -162,10 +161,10 @@ impl Group for NistP256 {
         Option::from(scalar.invert()).unwrap()
     }
 
-    fn from_element_slice_unchecked(
-        element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self::Elem> {
-        Option::from(ProjectivePoint::from_bytes(element_bits)).ok_or(Error::PointError)
+    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
+        PublicKey::from_sec1_bytes(element_bits)
+            .map(|public_key| public_key.to_projective())
+            .map_err(|_| Error::PointError)
     }
 
     fn to_arr(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -150,16 +150,16 @@ impl Group for NistP256 {
             .map_err(|_| Error::ScalarError)
     }
 
-    fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
-        Scalar::random(rng)
+    fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
+        *SecretKey::random(rng).to_nonzero_scalar()
     }
 
-    fn scalar_as_bytes(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
+    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
         scalar.into()
     }
 
-    fn scalar_invert(scalar: &Self::Scalar) -> Self::Scalar {
-        scalar.invert().unwrap_or(Scalar::zero())
+    fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar {
+        Option::from(scalar.invert()).unwrap()
     }
 
     fn from_element_slice_unchecked(

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -42,7 +42,7 @@ pub type L = U48;
 
 #[cfg(feature = "p256")]
 impl Group for NistP256 {
-    const SUITE_ID: usize = 0x0003;
+    const SUITE_ID: u16 = 0x0003;
 
     type Elem = ProjectivePoint;
 

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -144,28 +144,12 @@ impl Group for NistP256 {
         Ok(Scalar::from_be_bytes_reduced(result))
     }
 
-    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
-        SecretKey::from_be_bytes(scalar_bits)
-            .map(|secret_key| *secret_key.to_nonzero_scalar())
-            .map_err(|_| Error::ScalarError)
+    fn base_elem() -> Self::Elem {
+        ProjectivePoint::generator()
     }
 
-    fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
-        *SecretKey::random(rng).to_nonzero_scalar()
-    }
-
-    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
-        scalar.into()
-    }
-
-    fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar {
-        Option::from(scalar.invert()).unwrap()
-    }
-
-    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
-        PublicKey::from_sec1_bytes(element_bits)
-            .map(|public_key| public_key.to_projective())
-            .map_err(|_| Error::PointError)
+    fn identity_elem() -> Self::Elem {
+        ProjectivePoint::identity()
     }
 
     fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
@@ -176,17 +160,33 @@ impl Group for NistP256 {
         result
     }
 
-    fn base_elem() -> Self::Elem {
-        ProjectivePoint::generator()
+    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
+        PublicKey::from_sec1_bytes(element_bits)
+            .map(|public_key| public_key.to_projective())
+            .map_err(|_| Error::PointError)
     }
 
-    fn identity_elem() -> Self::Elem {
-        ProjectivePoint::identity()
+    fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
+        *SecretKey::random(rng).to_nonzero_scalar()
+    }
+
+    fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar {
+        Option::from(scalar.invert()).unwrap()
     }
 
     #[cfg(test)]
     fn zero_scalar() -> Self::Scalar {
         Scalar::zero()
+    }
+
+    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
+        scalar.into()
+    }
+
+    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
+        SecretKey::from_be_bytes(scalar_bits)
+            .map(|secret_key| *secret_key.to_nonzero_scalar())
+            .map_err(|_| Error::ScalarError)
     }
 }
 

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -29,7 +29,7 @@ use p256_::elliptic_curve::group::GroupEncoding;
 use p256_::elliptic_curve::ops::Reduce;
 use p256_::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256_::elliptic_curve::Field;
-use p256_::{AffinePoint, EncodedPoint, NistP256, ProjectivePoint, Scalar};
+use p256_::{AffinePoint, EncodedPoint, NistP256, ProjectivePoint, Scalar, SecretKey};
 use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable};
 
@@ -144,10 +144,10 @@ impl Group for NistP256 {
         Ok(Scalar::from_be_bytes_reduced(result))
     }
 
-    fn from_scalar_slice_unchecked(
-        scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar> {
-        Ok(Scalar::from_be_bytes_reduced(*scalar_bits))
+    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
+        SecretKey::from_be_bytes(scalar_bits)
+            .map(|secret_key| *secret_key.to_nonzero_scalar())
+            .map_err(|_| Error::ScalarError)
     }
 
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -27,7 +27,7 @@ pub struct Ristretto255;
 // `cfg` here is only needed because of a bug in Rust's crate feature documentation. See: https://github.com/rust-lang/rust/issues/83428
 #[cfg(feature = "ristretto255")]
 impl Group for Ristretto255 {
-    const SUITE_ID: usize = 0x0001;
+    const SUITE_ID: u16 = 0x0001;
 
     type Elem = RistrettoPoint;
 

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -108,11 +108,10 @@ impl Group for Ristretto255 {
         scalar.invert()
     }
 
-    fn from_element_slice_unchecked(
-        element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self::Elem> {
+    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
         CompressedRistretto::from_slice(element_bits)
             .decompress()
+            .filter(|point| point != &RistrettoPoint::identity())
             .ok_or(Error::PointError)
     }
 

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -31,6 +31,8 @@ impl Group for Ristretto255 {
 
     type Elem = RistrettoPoint;
 
+    type ElemLen = U32;
+
     type Scalar = Scalar;
 
     type ScalarLen = U32;
@@ -84,7 +86,7 @@ impl Group for Ristretto255 {
             .ok_or(Error::ScalarError)
     }
 
-    fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
+    fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
         loop {
             let scalar = {
                 let mut scalar_bytes = [0u8; 64];
@@ -98,16 +100,14 @@ impl Group for Ristretto255 {
         }
     }
 
-    fn scalar_as_bytes(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
+    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
         scalar.to_bytes().into()
     }
 
-    fn scalar_invert(scalar: &Self::Scalar) -> Self::Scalar {
+    fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar {
         scalar.invert()
     }
 
-    // The byte length necessary to represent group elements
-    type ElemLen = U32;
     fn from_element_slice_unchecked(
         element_bits: &GenericArray<u8, Self::ElemLen>,
     ) -> Result<Self::Elem> {

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -78,10 +78,10 @@ impl Group for Ristretto255 {
         ))
     }
 
-    fn from_scalar_slice_unchecked(
-        scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar> {
-        Ok(Scalar::from_bytes_mod_order(*scalar_bits.as_ref()))
+    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
+        Scalar::from_canonical_bytes((*scalar_bits).into())
+            .filter(|scalar| scalar != &Scalar::zero())
+            .ok_or(Error::ScalarError)
     }
 
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -116,19 +116,20 @@ impl Group for Ristretto255 {
     }
 
     // serialization of a group element
-    fn to_arr(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
+    fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
         elem.compress().to_bytes().into()
     }
 
-    fn base_point() -> Self::Elem {
+    fn base_elem() -> Self::Elem {
         RISTRETTO_BASEPOINT_POINT
     }
 
-    fn identity() -> Self::Elem {
+    fn identity_elem() -> Self::Elem {
         RistrettoPoint::identity()
     }
 
-    fn scalar_zero() -> Self::Scalar {
+    #[cfg(test)]
+    fn zero_scalar() -> Self::Scalar {
         Scalar::zero()
     }
 }

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -80,10 +80,24 @@ impl Group for Ristretto255 {
         ))
     }
 
-    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
-        Scalar::from_canonical_bytes((*scalar_bits).into())
-            .filter(|scalar| scalar != &Scalar::zero())
-            .ok_or(Error::ScalarError)
+    fn base_elem() -> Self::Elem {
+        RISTRETTO_BASEPOINT_POINT
+    }
+
+    fn identity_elem() -> Self::Elem {
+        RistrettoPoint::identity()
+    }
+
+    // serialization of a group element
+    fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
+        elem.compress().to_bytes().into()
+    }
+
+    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
+        CompressedRistretto::from_slice(element_bits)
+            .decompress()
+            .filter(|point| point != &RistrettoPoint::identity())
+            .ok_or(Error::PointError)
     }
 
     fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
@@ -100,36 +114,22 @@ impl Group for Ristretto255 {
         }
     }
 
-    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
-        scalar.to_bytes().into()
-    }
-
     fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar {
         scalar.invert()
-    }
-
-    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
-        CompressedRistretto::from_slice(element_bits)
-            .decompress()
-            .filter(|point| point != &RistrettoPoint::identity())
-            .ok_or(Error::PointError)
-    }
-
-    // serialization of a group element
-    fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
-        elem.compress().to_bytes().into()
-    }
-
-    fn base_elem() -> Self::Elem {
-        RISTRETTO_BASEPOINT_POINT
-    }
-
-    fn identity_elem() -> Self::Elem {
-        RistrettoPoint::identity()
     }
 
     #[cfg(test)]
     fn zero_scalar() -> Self::Scalar {
         Scalar::zero()
+    }
+
+    fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
+        scalar.to_bytes().into()
+    }
+
+    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
+        Scalar::from_canonical_bytes((*scalar_bits).into())
+            .filter(|scalar| scalar != &Scalar::zero())
+            .ok_or(Error::ScalarError)
     }
 }

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -45,8 +45,8 @@ fn test_identity_element_error<G: Group>() -> Result<()> {
 // Checks that the zero scalar cannot be deserialized
 fn test_zero_scalar_error<G: Group>() -> Result<()> {
     let zero_scalar = G::scalar_zero();
-    let result = G::from_scalar_slice(&G::scalar_as_bytes(zero_scalar));
-    assert!(matches!(result, Err(Error::ZeroScalarError)));
+    let result = G::deserialize_scalar(&G::scalar_as_bytes(zero_scalar));
+    assert!(matches!(result, Err(Error::ScalarError)));
 
     Ok(())
 }

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -16,18 +16,18 @@ use crate::{Error, Group, Result};
 fn test_group_properties() -> Result<()> {
     #[cfg(feature = "ristretto255")]
     {
-        use curve25519_dalek::ristretto::RistrettoPoint;
+        use crate::Ristretto255;
 
-        test_identity_element_error::<RistrettoPoint>()?;
-        test_zero_scalar_error::<RistrettoPoint>()?;
+        test_identity_element_error::<Ristretto255>()?;
+        test_zero_scalar_error::<Ristretto255>()?;
     }
 
     #[cfg(feature = "p256")]
     {
-        use p256_::ProjectivePoint;
+        use p256_::NistP256;
 
-        test_identity_element_error::<ProjectivePoint>()?;
-        test_zero_scalar_error::<ProjectivePoint>()?;
+        test_identity_element_error::<NistP256>()?;
+        test_zero_scalar_error::<NistP256>()?;
     }
 
     Ok(())
@@ -36,7 +36,7 @@ fn test_group_properties() -> Result<()> {
 // Checks that the identity element cannot be deserialized
 fn test_identity_element_error<G: Group>() -> Result<()> {
     let identity = G::identity();
-    let result = G::from_element_slice(&identity.to_arr());
+    let result = G::from_element_slice(&G::to_arr(identity));
     assert!(matches!(result, Err(Error::PointError)));
 
     Ok(())

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -45,7 +45,7 @@ fn test_identity_element_error<G: Group>() -> Result<()> {
 // Checks that the zero scalar cannot be deserialized
 fn test_zero_scalar_error<G: Group>() -> Result<()> {
     let zero_scalar = G::scalar_zero();
-    let result = G::deserialize_scalar(&G::scalar_as_bytes(zero_scalar));
+    let result = G::deserialize_scalar(&G::serialize_scalar(zero_scalar));
     assert!(matches!(result, Err(Error::ScalarError)));
 
     Ok(())

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -36,7 +36,7 @@ fn test_group_properties() -> Result<()> {
 // Checks that the identity element cannot be deserialized
 fn test_identity_element_error<G: Group>() -> Result<()> {
     let identity = G::identity();
-    let result = G::from_element_slice(&G::to_arr(identity));
+    let result = G::deserialize_elem(&G::to_arr(identity));
     assert!(matches!(result, Err(Error::PointError)));
 
     Ok(())

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -35,8 +35,8 @@ fn test_group_properties() -> Result<()> {
 
 // Checks that the identity element cannot be deserialized
 fn test_identity_element_error<G: Group>() -> Result<()> {
-    let identity = G::identity();
-    let result = G::deserialize_elem(&G::to_arr(identity));
+    let identity = G::identity_elem();
+    let result = G::deserialize_elem(&G::serialize_elem(identity));
     assert!(matches!(result, Err(Error::PointError)));
 
     Ok(())
@@ -44,7 +44,7 @@ fn test_identity_element_error<G: Group>() -> Result<()> {
 
 // Checks that the zero scalar cannot be deserialized
 fn test_zero_scalar_error<G: Group>() -> Result<()> {
-    let zero_scalar = G::scalar_zero();
+    let zero_scalar = G::zero_scalar();
     let result = G::deserialize_scalar(&G::serialize_scalar(zero_scalar));
     assert!(matches!(result, Err(Error::ScalarError)));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! We will use the following choices in this example:
 //!
 //! ```ignore
-//! type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! type Group = voprf::Ristretto255;
 //! type Hash = sha2::Sha512;
 //! ```
 //!
@@ -52,11 +52,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! use rand::rngs::OsRng;
@@ -78,11 +78,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! use rand::rngs::OsRng;
@@ -104,11 +104,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::NonVerifiableClient;
@@ -136,11 +136,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::NonVerifiableClient;
@@ -187,11 +187,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! use rand::rngs::OsRng;
@@ -220,11 +220,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! use rand::rngs::OsRng;
@@ -246,11 +246,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::VerifiableClient;
@@ -279,11 +279,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::VerifiableClient;
@@ -336,11 +336,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::VerifiableClient;
@@ -364,11 +364,11 @@
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::{VerifiableServerBatchEvaluatePrepareResult, VerifiableServerBatchEvaluateFinishResult, VerifiableClient};
@@ -407,11 +407,11 @@
 //! ```
 //! # #[cfg(feature = "alloc")] {
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::{VerifiableServerBatchEvaluateResult, VerifiableClient};
@@ -446,11 +446,11 @@
 //! ```
 //! # #[cfg(feature = "alloc")] {
 //! # #[cfg(feature = "ristretto255")]
-//! # type Group = curve25519_dalek::ristretto::RistrettoPoint;
+//! # type Group = voprf::Ristretto255;
 //! # #[cfg(feature = "ristretto255")]
 //! # type Hash = sha2::Sha512;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
-//! # type Group = p256_::ProjectivePoint;
+//! # type Group = p256_::NistP256;
 //! # #[cfg(all(feature = "p256", not(feature = "ristretto255")))]
 //! # type Hash = sha2::Sha256;
 //! # use voprf::{VerifiableServerBatchEvaluateResult, VerifiableClient};
@@ -507,9 +507,10 @@
 //! - The `alloc` feature requires Rusts [`alloc`] crate and enables batching
 //!   VOPRF evaluations.
 //!
-//! - The `p256` feature enables using p256 as the underlying group for the
-//!   [Group] choice and increases the MSRV to 1.56. Note that this is currently
-//!   an experimental feature ⚠️, and is not yet ready for production use.
+//! - The `p256` feature enables using [`NistP256`](p256_::NistP256) as the
+//!   underlying group for the [Group] choice and increases the MSRV to 1.56.
+//!   Note that this is currently an experimental feature ⚠️, and is not yet
+//!   ready for production use.
 //!
 //! - The `serde` feature, enabled by default, provides convenience functions
 //!   for serializing and deserializing with [serde](https://serde.rs/).
@@ -520,18 +521,21 @@
 //!   that need access to these raw values and are able to perform the necessary
 //!   validations on them (such as being valid group elements).
 //!
-//! - The backend features are re-exported from [curve25519-dalek](https://doc.dalek.rs/curve25519_dalek/index.html#backends-and-features)
-//!   and allow for selecting the corresponding backend for the curve arithmetic
-//!   used. The `ristretto255_u64` feature is included as the default. Other
-//!   features are mapped as `ristretto255_u32`, `ristretto255_fiat_u64` and
-//!   `ristretto255_fiat_u32`. Any `ristretto255_*` backend feature will enable
-//!   the `ristretto255` feature, which can be used too, but keep in mind that
-//!   `curve25519-dalek` will fail to compile without a selected backend.
+//! - The `ristretto255` feature enables using [`Ristretto255`] as the
+//!   underlying group for the [Group] choice. A backend feature, which are
+//!   re-exported from [curve25519-dalek] and allow for selecting the
+//!   corresponding backend for the curve arithmetic used, has to be selected,
+//!   otherwise compilation will fail. The `ristretto255_u64` feature is
+//!   included as the default. Other features are mapped as `ristretto255_u32`,
+//!   `ristretto255_fiat_u64` and `ristretto255_fiat_u32`. Any `ristretto255_*`
+//!   backend feature will enable the `ristretto255` feature.
 //!
-//! - The `ristretto255_simd` feature is re-exported from [curve25519-dalek](https://doc.dalek.rs/curve25519_dalek/index.html#backends-and-features)
-//!   and enables parallel formulas, using either AVX2 or AVX512-IFMA. This will
+//! - The `ristretto255_simd` feature is re-exported from [curve25519-dalek] and
+//!   enables parallel formulas, using either AVX2 or AVX512-IFMA. This will
 //!   automatically enable the `ristretto255_u64` feature and requires Rust
 //!   nightly.
+//!
+//! [curve25519-dalek]: (https://doc.dalek.rs/curve25519_dalek/index.html#backends-and-features)
 
 #![deny(unsafe_code)]
 #![no_std]
@@ -556,6 +560,9 @@ mod voprf;
 mod tests;
 
 // Exports
+
+#[cfg(feature = "ristretto255")]
+pub use group::Ristretto255;
 
 pub use crate::error::{Error, Result};
 pub use crate::group::Group;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,7 +569,7 @@ pub use crate::group::Group;
 #[cfg(feature = "alloc")]
 pub use crate::voprf::VerifiableServerBatchEvaluateResult;
 pub use crate::voprf::{
-    BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableClientBlindResult,
+    BlindedElement, EvaluationElement, Mode, NonVerifiableClient, NonVerifiableClientBlindResult,
     NonVerifiableServer, NonVerifiableServerEvaluateResult, PreparedEvaluationElement,
     PreparedTscalar, Proof, VerifiableClient, VerifiableClientBatchFinalizeResult,
     VerifiableClientBlindResult, VerifiableServer, VerifiableServerBatchEvaluateFinishResult,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -61,7 +61,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         let mut input = input.iter().copied();
 
         let blind = G::deserialize_scalar(&deserialize(&mut input)?)?;
-        let blinded_element = G::from_element_slice(&deserialize(&mut input)?)?;
+        let blinded_element = G::deserialize_elem(&deserialize(&mut input)?)?;
 
         Ok(Self {
             blind,
@@ -105,7 +105,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         let mut input = input.iter().copied();
 
         let sk = G::deserialize_scalar(&deserialize(&mut input)?)?;
-        let pk = G::from_element_slice(&deserialize(&mut input)?)?;
+        let pk = G::deserialize_elem(&deserialize(&mut input)?)?;
 
         Ok(Self {
             sk,
@@ -150,7 +150,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H
     pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
-        let value = G::from_element_slice(&deserialize(&mut input)?)?;
+        let value = G::deserialize_elem(&deserialize(&mut input)?)?;
 
         Ok(Self {
             value,
@@ -169,7 +169,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> EvaluationElement<G
     pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
-        let value = G::from_element_slice(&deserialize(&mut input)?)?;
+        let value = G::deserialize_elem(&deserialize(&mut input)?)?;
 
         Ok(Self {
             value,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -30,7 +30,7 @@ use crate::{
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableClient<G, H> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, G::ScalarLen> {
-        G::scalar_as_bytes(self.blind)
+        G::serialize_scalar(self.blind)
     }
 
     /// Deserialization from bytes
@@ -53,7 +53,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         G::ScalarLen: Add<G::ElemLen>,
         Sum<G::ScalarLen, G::ElemLen>: ArrayLength<u8>,
     {
-        G::scalar_as_bytes(self.blind).concat(G::to_arr(self.blinded_element))
+        G::serialize_scalar(self.blind).concat(G::to_arr(self.blinded_element))
     }
 
     /// Deserialization from bytes
@@ -74,7 +74,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer<G, H> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, G::ScalarLen> {
-        G::scalar_as_bytes(self.sk)
+        G::serialize_scalar(self.sk)
     }
 
     /// Deserialization from bytes
@@ -97,7 +97,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         G::ScalarLen: Add<G::ElemLen>,
         Sum<G::ScalarLen, G::ElemLen>: ArrayLength<u8>,
     {
-        G::scalar_as_bytes(self.sk).concat(G::to_arr(self.pk))
+        G::serialize_scalar(self.sk).concat(G::to_arr(self.pk))
     }
 
     /// Deserialization from bytes
@@ -122,7 +122,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> Proof<G, H> {
         G::ScalarLen: Add<G::ScalarLen>,
         Sum<G::ScalarLen, G::ScalarLen>: ArrayLength<u8>,
     {
-        G::scalar_as_bytes(self.c_scalar).concat(G::scalar_as_bytes(self.s_scalar))
+        G::serialize_scalar(self.c_scalar).concat(G::serialize_scalar(self.s_scalar))
     }
 
     /// Deserialization from bytes

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -37,7 +37,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableClient
     pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
-        let blind = G::from_scalar_slice(&deserialize(&mut input)?)?;
+        let blind = G::deserialize_scalar(&deserialize(&mut input)?)?;
 
         Ok(Self {
             blind,
@@ -60,7 +60,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
     pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
-        let blind = G::from_scalar_slice(&deserialize(&mut input)?)?;
+        let blind = G::deserialize_scalar(&deserialize(&mut input)?)?;
         let blinded_element = G::from_element_slice(&deserialize(&mut input)?)?;
 
         Ok(Self {
@@ -81,7 +81,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer
     pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
-        let sk = G::from_scalar_slice(&deserialize(&mut input)?)?;
+        let sk = G::deserialize_scalar(&deserialize(&mut input)?)?;
 
         Ok(Self {
             sk,
@@ -104,7 +104,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
     pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
-        let sk = G::from_scalar_slice(&deserialize(&mut input)?)?;
+        let sk = G::deserialize_scalar(&deserialize(&mut input)?)?;
         let pk = G::from_element_slice(&deserialize(&mut input)?)?;
 
         Ok(Self {
@@ -129,8 +129,8 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> Proof<G, H> {
     pub fn deserialize(input: &[u8]) -> Result<Self> {
         let mut input = input.iter().copied();
 
-        let c_scalar = G::from_scalar_slice(&deserialize(&mut input)?)?;
-        let s_scalar = G::from_scalar_slice(&deserialize(&mut input)?)?;
+        let c_scalar = G::deserialize_scalar(&deserialize(&mut input)?)?;
+        let s_scalar = G::deserialize_scalar(&deserialize(&mut input)?)?;
 
         Ok(Proof {
             c_scalar,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -53,7 +53,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         G::ScalarLen: Add<G::ElemLen>,
         Sum<G::ScalarLen, G::ElemLen>: ArrayLength<u8>,
     {
-        G::scalar_as_bytes(self.blind).concat(self.blinded_element.to_arr())
+        G::scalar_as_bytes(self.blind).concat(G::to_arr(self.blinded_element))
     }
 
     /// Deserialization from bytes
@@ -97,7 +97,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         G::ScalarLen: Add<G::ElemLen>,
         Sum<G::ScalarLen, G::ElemLen>: ArrayLength<u8>,
     {
-        G::scalar_as_bytes(self.sk).concat(self.pk.to_arr())
+        G::scalar_as_bytes(self.sk).concat(G::to_arr(self.pk))
     }
 
     /// Deserialization from bytes
@@ -143,7 +143,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> Proof<G, H> {
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, G::ElemLen> {
-        self.value.to_arr()
+        G::to_arr(self.value)
     }
 
     /// Deserialization from bytes
@@ -162,7 +162,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> EvaluationElement<G, H> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, G::ElemLen> {
-        self.value.to_arr()
+        G::to_arr(self.value)
     }
 
     /// Deserialization from bytes

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -53,7 +53,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         G::ScalarLen: Add<G::ElemLen>,
         Sum<G::ScalarLen, G::ElemLen>: ArrayLength<u8>,
     {
-        G::serialize_scalar(self.blind).concat(G::to_arr(self.blinded_element))
+        G::serialize_scalar(self.blind).concat(G::serialize_elem(self.blinded_element))
     }
 
     /// Deserialization from bytes
@@ -97,7 +97,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
         G::ScalarLen: Add<G::ElemLen>,
         Sum<G::ScalarLen, G::ElemLen>: ArrayLength<u8>,
     {
-        G::serialize_scalar(self.sk).concat(G::to_arr(self.pk))
+        G::serialize_scalar(self.sk).concat(G::serialize_elem(self.pk))
     }
 
     /// Deserialization from bytes
@@ -143,7 +143,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> Proof<G, H> {
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, G::ElemLen> {
-        G::to_arr(self.value)
+        G::serialize_elem(self.value)
     }
 
     /// Deserialization from bytes
@@ -162,7 +162,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H
 impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> EvaluationElement<G, H> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, G::ElemLen> {
-        G::to_arr(self.value)
+        G::serialize_elem(self.value)
     }
 
     /// Deserialization from bytes

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -184,7 +184,7 @@ fn test_base_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let blind =
-                G::from_scalar_slice(&GenericArray::clone_from_slice(&parameters.blind[i]))?;
+                G::deserialize_scalar(&GenericArray::clone_from_slice(&parameters.blind[i]))?;
             let client_result = NonVerifiableClient::<G, H>::deterministic_blind_unchecked(
                 &parameters.input[i],
                 blind,
@@ -210,7 +210,7 @@ fn test_verifiable_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let blind =
-                G::from_scalar_slice(&GenericArray::clone_from_slice(&parameters.blind[i]))?;
+                G::deserialize_scalar(&GenericArray::clone_from_slice(&parameters.blind[i]))?;
             let client_blind_result = VerifiableClient::<G, H>::deterministic_blind_unchecked(
                 &parameters.input[i],
                 blind,
@@ -299,7 +299,7 @@ fn test_base_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 ) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
-            let client = NonVerifiableClient::<G, H>::from_blind(G::from_scalar_slice(
+            let client = NonVerifiableClient::<G, H>::from_blind(G::deserialize_scalar(
                 &GenericArray::clone_from_slice(&parameters.blind[i]),
             )?);
 
@@ -322,7 +322,7 @@ fn test_verifiable_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputRes
         let mut clients = vec![];
         for i in 0..parameters.input.len() {
             let client = VerifiableClient::<G, H>::from_blind_and_element(
-                G::from_scalar_slice(&GenericArray::clone_from_slice(&parameters.blind[i]))?,
+                G::deserialize_scalar(&GenericArray::clone_from_slice(&parameters.blind[i]))?,
                 G::from_element_slice(&GenericArray::clone_from_slice(
                     &parameters.blinded_element[i],
                 ))?,

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -153,7 +153,7 @@ fn test_base_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>
 
         assert_eq!(
             &parameters.sksm,
-            &G::scalar_as_bytes(server.get_private_key()).to_vec()
+            &G::serialize_scalar(server.get_private_key()).to_vec()
         );
     }
     Ok(())
@@ -167,7 +167,7 @@ fn test_verifiable_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutput
 
         assert_eq!(
             &parameters.sksm,
-            &G::scalar_as_bytes(server.get_private_key()).to_vec()
+            &G::serialize_scalar(server.get_private_key()).to_vec()
         );
         assert_eq!(
             &parameters.pksm,
@@ -192,7 +192,7 @@ fn test_base_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 
             assert_eq!(
                 &parameters.blind[i],
-                &G::scalar_as_bytes(client_result.state.blind).to_vec()
+                &G::serialize_scalar(client_result.state.blind).to_vec()
             );
             assert_eq!(
                 parameters.blinded_element[i].as_slice(),
@@ -218,7 +218,7 @@ fn test_verifiable_blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>
 
             assert_eq!(
                 &parameters.blind[i],
-                &G::scalar_as_bytes(client_blind_result.state.get_blind()).to_vec()
+                &G::serialize_scalar(client_blind_result.state.get_blind()).to_vec()
             );
             assert_eq!(
                 parameters.blinded_element[i].as_slice(),

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -90,8 +90,9 @@ fn test_vectors() -> Result<()> {
 
     #[cfg(feature = "ristretto255")]
     {
-        use curve25519_dalek::ristretto::RistrettoPoint;
         use sha2::Sha512;
+
+        use crate::Ristretto255;
 
         let ristretto_base_tvs = json_to_test_vectors!(
             rfc,
@@ -105,20 +106,20 @@ fn test_vectors() -> Result<()> {
             String::from("Verifiable")
         );
 
-        test_base_seed_to_key::<RistrettoPoint, Sha512>(&ristretto_base_tvs)?;
-        test_base_blind::<RistrettoPoint, Sha512>(&ristretto_base_tvs)?;
-        test_base_evaluate::<RistrettoPoint, Sha512>(&ristretto_base_tvs)?;
-        test_base_finalize::<RistrettoPoint, Sha512>(&ristretto_base_tvs)?;
+        test_base_seed_to_key::<Ristretto255, Sha512>(&ristretto_base_tvs)?;
+        test_base_blind::<Ristretto255, Sha512>(&ristretto_base_tvs)?;
+        test_base_evaluate::<Ristretto255, Sha512>(&ristretto_base_tvs)?;
+        test_base_finalize::<Ristretto255, Sha512>(&ristretto_base_tvs)?;
 
-        test_verifiable_seed_to_key::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
-        test_verifiable_blind::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
-        test_verifiable_evaluate::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
-        test_verifiable_finalize::<RistrettoPoint, Sha512>(&ristretto_verifiable_tvs)?;
+        test_verifiable_seed_to_key::<Ristretto255, Sha512>(&ristretto_verifiable_tvs)?;
+        test_verifiable_blind::<Ristretto255, Sha512>(&ristretto_verifiable_tvs)?;
+        test_verifiable_evaluate::<Ristretto255, Sha512>(&ristretto_verifiable_tvs)?;
+        test_verifiable_finalize::<Ristretto255, Sha512>(&ristretto_verifiable_tvs)?;
     }
 
     #[cfg(feature = "p256")]
     {
-        use p256_::ProjectivePoint;
+        use p256_::NistP256;
         use sha2::Sha256;
 
         let p256_base_tvs =
@@ -130,15 +131,15 @@ fn test_vectors() -> Result<()> {
             String::from("Verifiable")
         );
 
-        test_base_seed_to_key::<ProjectivePoint, Sha256>(&p256_base_tvs)?;
-        test_base_blind::<ProjectivePoint, Sha256>(&p256_base_tvs)?;
-        test_base_evaluate::<ProjectivePoint, Sha256>(&p256_base_tvs)?;
-        test_base_finalize::<ProjectivePoint, Sha256>(&p256_base_tvs)?;
+        test_base_seed_to_key::<NistP256, Sha256>(&p256_base_tvs)?;
+        test_base_blind::<NistP256, Sha256>(&p256_base_tvs)?;
+        test_base_evaluate::<NistP256, Sha256>(&p256_base_tvs)?;
+        test_base_finalize::<NistP256, Sha256>(&p256_base_tvs)?;
 
-        test_verifiable_seed_to_key::<ProjectivePoint, Sha256>(&p256_verifiable_tvs)?;
-        test_verifiable_blind::<ProjectivePoint, Sha256>(&p256_verifiable_tvs)?;
-        test_verifiable_evaluate::<ProjectivePoint, Sha256>(&p256_verifiable_tvs)?;
-        test_verifiable_finalize::<ProjectivePoint, Sha256>(&p256_verifiable_tvs)?;
+        test_verifiable_seed_to_key::<NistP256, Sha256>(&p256_verifiable_tvs)?;
+        test_verifiable_blind::<NistP256, Sha256>(&p256_verifiable_tvs)?;
+        test_verifiable_evaluate::<NistP256, Sha256>(&p256_verifiable_tvs)?;
+        test_verifiable_finalize::<NistP256, Sha256>(&p256_verifiable_tvs)?;
     }
 
     Ok(())
@@ -168,7 +169,10 @@ fn test_verifiable_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutput
             &parameters.sksm,
             &G::scalar_as_bytes(server.get_private_key()).to_vec()
         );
-        assert_eq!(&parameters.pksm, &server.get_public_key().to_arr().to_vec());
+        assert_eq!(
+            &parameters.pksm,
+            G::to_arr(server.get_public_key()).as_slice()
+        );
     }
     Ok(())
 }

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -323,7 +323,7 @@ fn test_verifiable_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputRes
         for i in 0..parameters.input.len() {
             let client = VerifiableClient::<G, H>::from_blind_and_element(
                 G::deserialize_scalar(&GenericArray::clone_from_slice(&parameters.blind[i]))?,
-                G::from_element_slice(&GenericArray::clone_from_slice(
+                G::deserialize_elem(&GenericArray::clone_from_slice(
                     &parameters.blinded_element[i],
                 ))?,
             );
@@ -341,7 +341,7 @@ fn test_verifiable_finalize<G: Group, H: BlockSizeUser + Digest + FixedOutputRes
             &clients,
             &messages,
             &Proof::deserialize(&parameters.proof)?,
-            G::from_element_slice(GenericArray::from_slice(&parameters.pksm))?,
+            G::deserialize_elem(GenericArray::from_slice(&parameters.pksm))?,
             Some(&parameters.info),
         )?;
 

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -171,7 +171,7 @@ fn test_verifiable_seed_to_key<G: Group, H: BlockSizeUser + Digest + FixedOutput
         );
         assert_eq!(
             &parameters.pksm,
-            G::to_arr(server.get_public_key()).as_slice()
+            G::serialize_elem(server.get_public_key()).as_slice()
         );
     }
     Ok(())

--- a/src/tests/voprf_vectors.rs
+++ b/src/tests/voprf_vectors.rs
@@ -8,7 +8,7 @@
 //! The VOPRF test vectors taken from:
 //! https://github.com/cfrg/draft-irtf-cfrg-voprf/blob/master/draft-irtf-cfrg-voprf.md
 
-pub(crate) static VECTORS: &str = r#"
+pub(crate) const VECTORS: &str = r#"
 ## OPRF(ristretto255, SHA-512)
 
 ### Base Mode

--- a/src/util.rs
+++ b/src/util.rs
@@ -142,14 +142,11 @@ mod unit_tests {
         ($item:ident, $bytes:ident) => {
             #[cfg(feature = "ristretto255")]
             {
-                let _ =
-                    $item::<curve25519_dalek::ristretto::RistrettoPoint, sha2::Sha512>::deserialize(
-                        &$bytes[..],
-                    );
+                let _ = $item::<crate::Ristretto255, sha2::Sha512>::deserialize(&$bytes[..]);
             }
             #[cfg(feature = "p256")]
             {
-                let _ = $item::<p256_::ProjectivePoint, sha2::Sha256>::deserialize(&$bytes[..]);
+                let _ = $item::<p256_::NistP256, sha2::Sha256>::deserialize(&$bytes[..]);
             }
         };
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,136 +7,34 @@
 
 //! Helper functions
 
-use core::array::IntoIter;
+use core::convert::TryFrom;
 
-use generic_array::typenum::U0;
+use generic_array::typenum::{IsLess, U2, U256};
 use generic_array::{ArrayLength, GenericArray};
 
 use crate::{Error, Result};
 
-// Corresponds to the I2OSP() function from RFC8017
-pub(crate) fn i2osp<L: ArrayLength<u8>>(input: usize) -> Result<GenericArray<u8, L>> {
-    const SIZEOF_USIZE: usize = core::mem::size_of::<usize>();
-
-    // Make sure input fits in output.
-    if (SIZEOF_USIZE as u32 - input.leading_zeros() / 8) > L::U32 {
-        return Err(Error::SerializationError);
-    }
-
-    let mut output = GenericArray::default();
-    output[L::USIZE.saturating_sub(SIZEOF_USIZE)..]
-        .copy_from_slice(&input.to_be_bytes()[SIZEOF_USIZE.saturating_sub(L::USIZE)..]);
-    Ok(output)
+pub(crate) fn i2osp_2(input: usize) -> Result<GenericArray<u8, U2>> {
+    u16::try_from(input)
+        .map(|input| input.to_be_bytes().into())
+        .map_err(|_| Error::SerializationError)
 }
 
-/// Computes `I2OSP(len(input), max_bytes) || input` and helps hold output
-/// without allocation.
-pub(crate) struct Serialize<'a, L1: ArrayLength<u8>, L2: ArrayLength<u8> = U0> {
-    octet: GenericArray<u8, L1>,
-    input: Input<'a, L2>,
-}
-
-enum Input<'a, L: ArrayLength<u8>> {
-    Owned(GenericArray<u8, L>),
-    Borrowed(&'a [u8]),
-}
-
-impl<'a, L1: ArrayLength<u8>, L2: ArrayLength<u8>> IntoIterator for &'a Serialize<'a, L1, L2> {
-    type Item = &'a [u8];
-
-    type IntoIter = IntoIter<&'a [u8], 2>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        // MSRV: array `into_iter` isn't available in 1.51
-        #[allow(deprecated)]
-        IntoIter::new([
-            &self.octet,
-            match self.input {
-                Input::Owned(ref bytes) => bytes,
-                Input::Borrowed(bytes) => bytes,
-            },
-        ])
-    }
-}
-
-impl<'a, L1: ArrayLength<u8>, L2: ArrayLength<u8>> Serialize<'a, L1, L2> {
-    // Variation of `serialize` that takes a borrowed `input.
-    pub(crate) fn from(input: &[u8]) -> Result<Serialize<L1>> {
-        Ok(Serialize {
-            octet: i2osp::<L1>(input.len())?,
-            input: Input::Borrowed(input),
-        })
-    }
-
-    pub(crate) fn from_owned(input: GenericArray<u8, L2>) -> Result<Serialize<'static, L1, L2>> {
-        Ok(Serialize {
-            octet: i2osp::<L1>(input.len())?,
-            input: Input::Owned(input),
-        })
-    }
-}
-
-macro_rules! chain_name {
-    ($var:ident, $mod:ident) => {
-        $mod
-    };
-    ($var:ident) => {
-        $var
-    };
-}
-
-macro_rules! chain_skip {
-    ($var:ident, $feed:expr) => {
-        $feed
-    };
-    ($var:ident) => {
-        &$var
-    };
-}
-
-/// The purpose of this macro is to replace
-/// [`concat`](alloc::slice::Concat::concat)ing slices into an [`Iterator`] to
-/// avoid allocation
-macro_rules! chain {
-    (
-        $var:ident,
-        $item1:expr $(=> |$mod1:ident| $feed1:expr)?,
-        $($item2:expr $(=> |$mod2:ident| $feed2:expr)?),+$(,)?
-    ) => {
-        let chain_name!(__temp$(, $mod1)?) = $item1;
-        let $var = (chain_skip!(__temp$(, $feed1)?)).into_iter();
-        $(
-            let chain_name!(__temp$(, $mod2)?) = $item2;
-            let $var = $var.chain(chain_skip!(__temp$(, $feed2)?));
-        )+
-    };
+pub(crate) fn i2osp_2_array<L: ArrayLength<u8> + IsLess<U256>>(
+    _: GenericArray<u8, L>,
+) -> GenericArray<u8, U2> {
+    L::U16.to_be_bytes().into()
 }
 
 #[cfg(test)]
 mod unit_tests {
-    use generic_array::typenum::{U1, U2};
     use proptest::collection::vec;
     use proptest::prelude::*;
 
-    use super::*;
     use crate::{
         BlindedElement, EvaluationElement, NonVerifiableClient, NonVerifiableServer, Proof,
         VerifiableClient, VerifiableServer,
     };
-
-    // Test the error condition for I2OSP
-    #[test]
-    fn test_i2osp_err_check() {
-        assert!(i2osp::<U1>(0).is_ok());
-
-        assert!(i2osp::<U1>(255).is_ok());
-        assert!(i2osp::<U1>(256).is_err());
-        assert!(i2osp::<U1>(257).is_err());
-
-        assert!(i2osp::<U2>(256 * 256 - 1).is_ok());
-        assert!(i2osp::<U2>(256 * 256).is_err());
-        assert!(i2osp::<U2>(256 * 256 + 1).is_err());
-    }
 
     macro_rules! test_deserialize {
         ($item:ident, $bytes:ident) => {

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -414,7 +414,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> NonVerifiableServer
     /// Produces a new instance of a [NonVerifiableServer] using a supplied set
     /// of bytes to represent the server's private key
     pub fn new_with_key(private_key_bytes: &[u8]) -> Result<Self> {
-        let sk = G::from_scalar_slice(private_key_bytes)?;
+        let sk = G::deserialize_scalar(private_key_bytes.into())?;
         Ok(Self {
             sk,
             hash: PhantomData,
@@ -480,7 +480,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
     /// Produces a new instance of a [VerifiableServer] using a supplied set of
     /// bytes to represent the server's private key
     pub fn new_with_key(key: &[u8]) -> Result<Self> {
-        let sk = G::from_scalar_slice(key)?;
+        let sk = G::deserialize_scalar(key.into())?;
         let pk = G::base_point() * &sk;
         Ok(Self {
             sk,

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -74,18 +74,18 @@ pub struct NonVerifiableClient<G: Group, H: BlockSizeUser + Digest + FixedOutput
 /// that the OPRF outputs can be checked against a server public key.
 #[derive(DeriveWhere)]
 #[derive_where(Clone, Zeroize(drop))]
-#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G, G::Scalar)]
+#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G::Elem, G::Scalar)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "G::Scalar: serde::Deserialize<'de>, G: serde::Deserialize<'de>",
-        serialize = "G::Scalar: serde::Serialize, G: serde::Serialize"
+        deserialize = "G::Scalar: serde::Deserialize<'de>, G::Elem: serde::Deserialize<'de>",
+        serialize = "G::Scalar: serde::Serialize, G::Elem: serde::Serialize"
     ))
 )]
 pub struct VerifiableClient<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> {
     pub(crate) blind: G::Scalar,
-    pub(crate) blinded_element: G,
+    pub(crate) blinded_element: G::Elem,
     #[derive_where(skip(Zeroize))]
     pub(crate) hash: PhantomData<H>,
 }
@@ -113,18 +113,18 @@ pub struct NonVerifiableServer<G: Group, H: BlockSizeUser + Digest + FixedOutput
 /// that the OPRF outputs can be checked against a server public key.
 #[derive(DeriveWhere)]
 #[derive_where(Clone, Zeroize(drop))]
-#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G, G::Scalar)]
+#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G::Elem, G::Scalar)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "G::Scalar: serde::Deserialize<'de>, G: serde::Deserialize<'de>",
-        serialize = "G::Scalar: serde::Serialize, G: serde::Serialize"
+        deserialize = "G::Scalar: serde::Deserialize<'de>, G::Elem: serde::Deserialize<'de>",
+        serialize = "G::Scalar: serde::Serialize, G::Elem: serde::Serialize"
     ))
 )]
 pub struct VerifiableServer<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> {
     pub(crate) sk: G::Scalar,
-    pub(crate) pk: G,
+    pub(crate) pk: G::Elem,
     #[derive_where(skip(Zeroize))]
     pub(crate) hash: PhantomData<H>,
 }
@@ -153,17 +153,17 @@ pub struct Proof<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> {
 /// server (either verifiable or not).
 #[derive(DeriveWhere)]
 #[derive_where(Clone, Zeroize(drop))]
-#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G)]
+#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G::Elem)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "G: serde::Deserialize<'de>",
-        serialize = "G: serde::Serialize"
+        deserialize = "G::Elem: serde::Deserialize<'de>",
+        serialize = "G::Elem: serde::Serialize"
     ))
 )]
 pub struct BlindedElement<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> {
-    pub(crate) value: G,
+    pub(crate) value: G::Elem,
     #[derive_where(skip(Zeroize))]
     pub(crate) hash: PhantomData<H>,
 }
@@ -172,17 +172,17 @@ pub struct BlindedElement<G: Group, H: BlockSizeUser + Digest + FixedOutputReset
 /// verifiable or not) to a server (either verifiable or not).
 #[derive(DeriveWhere)]
 #[derive_where(Clone, Zeroize(drop))]
-#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G)]
+#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G::Elem)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "G: serde::Deserialize<'de>",
-        serialize = "G: serde::Serialize"
+        deserialize = "G::Elem: serde::Deserialize<'de>",
+        serialize = "G::Elem: serde::Serialize"
     ))
 )]
 pub struct EvaluationElement<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> {
-    pub(crate) value: G,
+    pub(crate) value: G::Elem,
     #[derive_where(skip(Zeroize))]
     pub(crate) hash: PhantomData<H>,
 }
@@ -328,7 +328,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         input: &[u8],
         evaluation_element: &EvaluationElement<G, H>,
         proof: &Proof<G, H>,
-        pk: G,
+        pk: G::Elem,
         metadata: Option<&[u8]>,
     ) -> Result<Output<H>> {
         // `core::array::from_ref` needs a MSRV of 1.53
@@ -350,7 +350,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
         clients: &'a IC,
         messages: &'a IM,
         proof: &Proof<G, H>,
-        pk: G,
+        pk: G::Elem,
         metadata: Option<&'a [u8]>,
     ) -> Result<VerifiableClientBatchFinalizeResult<'a, G, H, I, II, IC, IM>>
     where
@@ -379,7 +379,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableClient<G,
 
     #[cfg(test)]
     /// Only used for test functions
-    pub fn from_blind_and_element(blind: G::Scalar, blinded_element: G) -> Self {
+    pub fn from_blind_and_element(blind: G::Scalar, blinded_element: G::Elem) -> Self {
         Self {
             blind,
             blinded_element,
@@ -647,7 +647,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> VerifiableServer<G,
     }
 
     /// Retrieves the server's public key
-    pub fn get_public_key(&self) -> G {
+    pub fn get_public_key(&self) -> G::Elem {
         self.pk
     }
 }
@@ -783,7 +783,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H
     ///
     /// This should be used with caution, since it does not perform any checks
     /// on the validity of the value itself!
-    pub fn from_value_unchecked(value: G) -> Self {
+    pub fn from_value_unchecked(value: G::Elem) -> Self {
         Self {
             value,
             hash: PhantomData,
@@ -792,7 +792,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> BlindedElement<G, H
 
     #[cfg(feature = "danger")]
     /// Exposes the internal value
-    pub fn value(&self) -> G {
+    pub fn value(&self) -> G::Elem {
         self.value
     }
 }
@@ -813,7 +813,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> EvaluationElement<G
     ///
     /// This should be used with caution, since it does not perform any checks
     /// on the validity of the value itself!
-    pub fn from_value_unchecked(value: G) -> Self {
+    pub fn from_value_unchecked(value: G::Elem) -> Self {
         Self {
             value,
             hash: PhantomData,
@@ -822,7 +822,7 @@ impl<G: Group, H: BlockSizeUser + Digest + FixedOutputReset> EvaluationElement<G
 
     #[cfg(feature = "danger")]
     /// Exposes the internal value
-    pub fn value(&self) -> G {
+    pub fn value(&self) -> G::Elem {
         self.value
     }
 }
@@ -832,7 +832,7 @@ fn blind<G: Group, H: BlockSizeUser + Digest + FixedOutputReset, R: RngCore + Cr
     input: &[u8],
     blinding_factor_rng: &mut R,
     mode: Mode,
-) -> Result<(G::Scalar, G)> {
+) -> Result<(G::Scalar, G::Elem)> {
     // Choose a random scalar that must be non-zero
     let blind = G::random_nonzero_scalar(blinding_factor_rng);
     let blinded_element = deterministic_blind_unchecked::<G, H>(input, &blind, mode)?;
@@ -846,7 +846,7 @@ fn deterministic_blind_unchecked<G: Group, H: BlockSizeUser + Digest + FixedOutp
     input: &[u8],
     blind: &G::Scalar,
     mode: Mode,
-) -> Result<G> {
+) -> Result<G::Elem> {
     let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(get_context_string::<G>(mode)?);
     let hashed_point = G::hash_to_curve::<H, _>(input, dst)?;
     Ok(hashed_point * blind)
@@ -860,7 +860,7 @@ type VerifiableUnblindResult<'a, G, H, IC, IM> = Map<
         >,
         <&'a IM as IntoIterator>::IntoIter,
     >,
-    fn((<G as Group>::Scalar, &EvaluationElement<G, H>)) -> G,
+    fn((<G as Group>::Scalar, &EvaluationElement<G, H>)) -> <G as Group>::Elem,
 >;
 
 fn verifiable_unblind<
@@ -872,7 +872,7 @@ fn verifiable_unblind<
 >(
     clients: &'a IC,
     messages: &'a IM,
-    pk: G,
+    pk: G::Elem,
     proof: &Proof<G, H>,
     info: &[u8],
 ) -> Result<VerifiableUnblindResult<'a, G, H, IC, IM>>
@@ -921,8 +921,8 @@ fn generate_proof<
 >(
     rng: &mut R,
     k: G::Scalar,
-    a: G,
-    b: G,
+    a: G::Elem,
+    b: G::Elem,
     cs: impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
     ds: impl Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
 ) -> Result<Proof<G, H>> {
@@ -936,11 +936,11 @@ fn generate_proof<
         GenericArray::from(STR_CHALLENGE).concat(get_context_string::<G>(Mode::Verifiable)?);
     chain!(
         h2_input,
-        Serialize::<U2, _>::from_owned(b.to_arr())?,
-        Serialize::<U2, _>::from_owned(m.to_arr())?,
-        Serialize::<U2, _>::from_owned(z.to_arr())?,
-        Serialize::<U2, _>::from_owned(t2.to_arr())?,
-        Serialize::<U2, _>::from_owned(t3.to_arr())?,
+        Serialize::<U2, _>::from_owned(G::to_arr(b))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(m))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(z))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(t2))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(t3))?,
         Serialize::<U2, _>::from_owned(challenge_dst)?,
     );
 
@@ -959,8 +959,8 @@ fn generate_proof<
 
 #[allow(clippy::many_single_char_names)]
 fn verify_proof<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
-    a: G,
-    b: G,
+    a: G::Elem,
+    b: G::Elem,
     cs: impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
     ds: impl Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
     proof: &Proof<G, H>,
@@ -973,11 +973,11 @@ fn verify_proof<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
         GenericArray::from(STR_CHALLENGE).concat(get_context_string::<G>(Mode::Verifiable)?);
     chain!(
         h2_input,
-        Serialize::<U2, _>::from_owned(b.to_arr())?,
-        Serialize::<U2, _>::from_owned(m.to_arr())?,
-        Serialize::<U2, _>::from_owned(z.to_arr())?,
-        Serialize::<U2, _>::from_owned(t2.to_arr())?,
-        Serialize::<U2, _>::from_owned(t3.to_arr())?,
+        Serialize::<U2, _>::from_owned(G::to_arr(b))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(m))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(z))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(t2))?,
+        Serialize::<U2, _>::from_owned(G::to_arr(t3))?,
         Serialize::<U2, _>::from_owned(challenge_dst)?,
     );
 
@@ -993,7 +993,7 @@ fn verify_proof<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 
 type FinalizeAfterUnblindResult<'a, G, H, I, IE> = Map<
     Zip<IE, Repeat<(&'a [u8], GenericArray<u8, U20>)>>,
-    fn(((I, G), (&'a [u8], GenericArray<u8, U20>))) -> Result<Output<H>>,
+    fn(((I, <G as Group>::Elem), (&'a [u8], GenericArray<u8, U20>))) -> Result<Output<H>>,
 >;
 
 fn finalize_after_unblind<
@@ -1001,7 +1001,7 @@ fn finalize_after_unblind<
     G: Group,
     H: BlockSizeUser + Digest + FixedOutputReset,
     I: AsRef<[u8]>,
-    IE: 'a + Iterator<Item = (I, G)>,
+    IE: 'a + Iterator<Item = (I, G::Elem)>,
 >(
     inputs_and_unblinded_elements: IE,
     info: &'a [u8],
@@ -1018,7 +1018,7 @@ fn finalize_after_unblind<
                 hash_input,
                 Serialize::<U2>::from(input.as_ref())?,
                 Serialize::<U2>::from(info)?,
-                Serialize::<U2, _>::from_owned(unblinded_element.to_arr())?,
+                Serialize::<U2, _>::from_owned(G::to_arr(unblinded_element))?,
                 Serialize::<U2, _>::from_owned(finalize_dst)?,
             );
 
@@ -1030,10 +1030,10 @@ fn finalize_after_unblind<
 
 fn compute_composites<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
     k_option: Option<G::Scalar>,
-    b: G,
+    b: G::Elem,
     c_slice: impl Iterator<Item = EvaluationElement<G, H>> + ExactSizeIterator,
     d_slice: impl Iterator<Item = BlindedElement<G, H>> + ExactSizeIterator,
-) -> Result<(G, G)> {
+) -> Result<(G::Elem, G::Elem)> {
     if c_slice.len() != d_slice.len() {
         return Err(Error::MismatchedLengthsForCompositeInputs);
     }
@@ -1044,7 +1044,7 @@ fn compute_composites<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
 
     chain!(
         h1_input,
-        Serialize::<U2, _>::from_owned(b.to_arr())?,
+        Serialize::<U2, _>::from_owned(G::to_arr(b))?,
         Serialize::<U2, _>::from_owned(seed_dst)?,
     );
     let seed = h1_input
@@ -1058,8 +1058,8 @@ fn compute_composites<G: Group, H: BlockSizeUser + Digest + FixedOutputReset>(
         chain!(h2_input,
             Serialize::<U2, _>::from_owned(seed.clone())?,
             i2osp::<U2>(i)? => |x| Some(x.as_slice()),
-            Serialize::<U2, _>::from_owned(c.value.to_arr())?,
-            Serialize::<U2, _>::from_owned(d.value.to_arr())?,
+            Serialize::<U2, _>::from_owned(G::to_arr(c.value))?,
+            Serialize::<U2, _>::from_owned(G::to_arr(d.value))?,
             Serialize::<U2, _>::from_owned(composite_dst)?,
         );
         let dst = GenericArray::from(STR_HASH_TO_SCALAR)
@@ -1415,38 +1415,39 @@ mod tests {
     fn test_functionality() -> Result<()> {
         #[cfg(feature = "ristretto255")]
         {
-            use curve25519_dalek::ristretto::RistrettoPoint;
             use sha2::Sha512;
 
-            base_retrieval::<RistrettoPoint, Sha512>();
-            base_inversion_unsalted::<RistrettoPoint, Sha512>();
-            verifiable_retrieval::<RistrettoPoint, Sha512>();
-            verifiable_batch_retrieval::<RistrettoPoint, Sha512>();
-            verifiable_bad_public_key::<RistrettoPoint, Sha512>();
-            verifiable_batch_bad_public_key::<RistrettoPoint, Sha512>();
+            use crate::Ristretto255;
 
-            zeroize_base_client::<RistrettoPoint, Sha512>();
-            zeroize_base_server::<RistrettoPoint, Sha512>();
-            zeroize_verifiable_client::<RistrettoPoint, Sha512>();
-            zeroize_verifiable_server::<RistrettoPoint, Sha512>();
+            base_retrieval::<Ristretto255, Sha512>();
+            base_inversion_unsalted::<Ristretto255, Sha512>();
+            verifiable_retrieval::<Ristretto255, Sha512>();
+            verifiable_batch_retrieval::<Ristretto255, Sha512>();
+            verifiable_bad_public_key::<Ristretto255, Sha512>();
+            verifiable_batch_bad_public_key::<Ristretto255, Sha512>();
+
+            zeroize_base_client::<Ristretto255, Sha512>();
+            zeroize_base_server::<Ristretto255, Sha512>();
+            zeroize_verifiable_client::<Ristretto255, Sha512>();
+            zeroize_verifiable_server::<Ristretto255, Sha512>();
         }
 
         #[cfg(feature = "p256")]
         {
-            use p256_::ProjectivePoint;
+            use p256_::NistP256;
             use sha2::Sha256;
 
-            base_retrieval::<ProjectivePoint, Sha256>();
-            base_inversion_unsalted::<ProjectivePoint, Sha256>();
-            verifiable_retrieval::<ProjectivePoint, Sha256>();
-            verifiable_batch_retrieval::<ProjectivePoint, Sha256>();
-            verifiable_bad_public_key::<ProjectivePoint, Sha256>();
-            verifiable_batch_bad_public_key::<ProjectivePoint, Sha256>();
+            base_retrieval::<NistP256, Sha256>();
+            base_inversion_unsalted::<NistP256, Sha256>();
+            verifiable_retrieval::<NistP256, Sha256>();
+            verifiable_batch_retrieval::<NistP256, Sha256>();
+            verifiable_bad_public_key::<NistP256, Sha256>();
+            verifiable_batch_bad_public_key::<NistP256, Sha256>();
 
-            zeroize_base_client::<ProjectivePoint, Sha256>();
-            zeroize_base_server::<ProjectivePoint, Sha256>();
-            zeroize_verifiable_client::<ProjectivePoint, Sha256>();
-            zeroize_verifiable_server::<ProjectivePoint, Sha256>();
+            zeroize_base_client::<NistP256, Sha256>();
+            zeroize_base_server::<NistP256, Sha256>();
+            zeroize_verifiable_client::<NistP256, Sha256>();
+            zeroize_verifiable_server::<NistP256, Sha256>();
         }
 
         Ok(())


### PR DESCRIPTION
Replaces #49.

- Move `Group` constraints to associated type: `Elem`.
- Implement `Group` for `NistP256` instead of `ProjectivePoint`.
- Implement `Group` for `Ristretto255`, our own type, instead of `RistrettoPoint`. This type is re-exported.
- Change `SUITE_ID` to `u16`.
- Reworked scalar de-serialization, now scalars are actually checked for validity and not reduced or clamped into validity. Zero-checking is now not a separate function.
- Reworked `hash_to_scalar` and `hash_to_curve` not take iterators anymore in preparation of RustCrypto/traits#876. This included reverting a lot of convenience utilities. Maybe we will come up with alternatives in the future.
- Reworked `expand_message_xmd` in with some additional constraints according to the spec.
- Simplify P-256 `HashToScalar` implementation.