### PR TITLE
General improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ristretto255-fiat-u64 = ["curve25519-dalek/fiat_u64_backend", "ristretto255"]
 ristretto255-simd = ["curve25519-dalek/simd_backend", "ristretto255"]
 ristretto255-u32 = ["curve25519-dalek/u32_backend", "ristretto255"]
 ristretto255-u64 = ["curve25519-dalek/u64_backend", "ristretto255"]
+serde = ["generic-array/serde", "serde_"]
 std = ["alloc"]
 
 [dependencies]
@@ -36,7 +37,7 @@ elliptic-curve = { version = "0.12.0-pre.1", features = [
 ] }
 generic-array = "0.14"
 rand_core = { version = "0.6", default-features = false }
-serde = { version = "1", default-features = false, features = [
+serde_ = { version = "1", package = "serde", default-features = false, features = [
   "derive",
 ], optional = true }
 sha2 = { version = "0.10", default-features = false, optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,8 @@ pub enum Error {
     ProofVerification,
     /// Size of seed is longer then [`u16::MAX`].
     Seed,
+    /// The protocol has failed and can't be completed.
+    Protocol,
 }
 
 /// Only used to implement [`Group`](crate::Group).

--- a/src/group/elliptic_curve.rs
+++ b/src/group/elliptic_curve.rs
@@ -89,7 +89,7 @@ where
         result
     }
 
-    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
+    fn deserialize_elem(element_bits: &[u8]) -> Result<Self::Elem> {
         PublicKey::<Self>::from_sec1_bytes(element_bits)
             .map(|public_key| public_key.to_projective())
             .map_err(|_| Error::Deserialization)
@@ -116,7 +116,7 @@ where
         scalar.into()
     }
 
-    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
+    fn deserialize_scalar(scalar_bits: &[u8]) -> Result<Self::Scalar> {
         SecretKey::<Self>::from_be_bytes(scalar_bits)
             .map(|secret_key| *secret_key.to_nonzero_scalar())
             .map_err(|_| Error::Deserialization)

--- a/src/group/elliptic_curve.rs
+++ b/src/group/elliptic_curve.rs
@@ -103,6 +103,10 @@ where
         Option::from(scalar.invert()).unwrap()
     }
 
+    fn is_zero_scalar(scalar: Self::Scalar) -> subtle::Choice {
+        scalar.is_zero()
+    }
+
     #[cfg(test)]
     fn zero_scalar() -> Self::Scalar {
         Scalar::<Self>::zero()

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -93,7 +93,7 @@ pub trait Group {
     /// # Errors
     /// [`Error::Deserialization`](crate::Error::Deserialization) if the element
     /// is not a valid point on the group or the identity element.
-    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem>;
+    fn deserialize_elem(element_bits: &[u8]) -> Result<Self::Elem>;
 
     /// picks a scalar at random
     fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;
@@ -117,7 +117,7 @@ pub trait Group {
     /// # Errors
     /// [`Error::Deserialization`](crate::Error::Deserialization) if the scalar
     /// is not a valid point on the group or zero.
-    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar>;
+    fn deserialize_scalar(scalar_bits: &[u8]) -> Result<Self::Scalar>;
 }
 
 #[cfg(test)]

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -20,7 +20,7 @@ use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "ristretto255")]
 pub use ristretto::Ristretto255;
-use subtle::ConstantTimeEq;
+use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
 use crate::voprf::Mode;
@@ -100,6 +100,9 @@ pub trait Group {
 
     /// The multiplicative inverse of this scalar
     fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar;
+
+    /// Returns `true` if the scalar is zero.
+    fn is_zero_scalar(scalar: Self::Scalar) -> Choice;
 
     /// Returns the scalar representing zero
     #[cfg(test)]

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -16,6 +16,7 @@ use generic_array::sequence::Concat;
 use generic_array::typenum::{IsLess, IsLessOrEqual, U256, U32, U64};
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
+use subtle::ConstantTimeEq;
 
 use super::{Group, STR_HASH_TO_GROUP, STR_HASH_TO_SCALAR};
 use crate::voprf::{self, Mode};
@@ -125,6 +126,10 @@ impl Group for Ristretto255 {
 
     fn invert_scalar(scalar: Self::Scalar) -> Self::Scalar {
         scalar.invert()
+    }
+
+    fn is_zero_scalar(scalar: Self::Scalar) -> subtle::Choice {
+        scalar.ct_eq(&Scalar::zero())
     }
 
     #[cfg(test)]

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -22,6 +22,9 @@ use crate::voprf::{self, Mode};
 use crate::{CipherSuite, Error, InternalError, Result};
 
 /// [`Group`] implementation for Ristretto255.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+// `cfg` here is only needed because of a bug in Rust's crate feature documentation. See: https://github.com/rust-lang/rust/issues/83428
+#[cfg(feature = "ristretto255")]
 pub struct Ristretto255;
 
 #[cfg(feature = "ristretto255-ciphersuite")]

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -103,7 +103,7 @@ impl Group for Ristretto255 {
         elem.compress().to_bytes().into()
     }
 
-    fn deserialize_elem(element_bits: &GenericArray<u8, Self::ElemLen>) -> Result<Self::Elem> {
+    fn deserialize_elem(element_bits: &[u8]) -> Result<Self::Elem> {
         CompressedRistretto::from_slice(element_bits)
             .decompress()
             .filter(|point| point != &RistrettoPoint::identity())
@@ -141,8 +141,11 @@ impl Group for Ristretto255 {
         scalar.to_bytes().into()
     }
 
-    fn deserialize_scalar(scalar_bits: &GenericArray<u8, Self::ScalarLen>) -> Result<Self::Scalar> {
-        Scalar::from_canonical_bytes((*scalar_bits).into())
+    fn deserialize_scalar(scalar_bits: &[u8]) -> Result<Self::Scalar> {
+        scalar_bits
+            .try_into()
+            .ok()
+            .and_then(Scalar::from_canonical_bytes)
             .filter(|scalar| scalar != &Scalar::zero())
             .ok_or(Error::Deserialization)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,8 @@
 //!
 //! In the second step, the server takes as input the message from
 //! [NonVerifiableClient::blind] (a [BlindedElement]), and runs
-//! [NonVerifiableServer::evaluate] to produce a
-//! [NonVerifiableServerEvaluateResult], which consists of an
-//! [EvaluationElement] to be sent to the client.
+//! [NonVerifiableServer::evaluate] to produce [EvaluationElement] to be sent to
+//! the client.
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
@@ -135,13 +134,13 @@
 //! # use voprf::NonVerifiableServer;
 //! # let mut server_rng = OsRng;
 //! # let server = NonVerifiableServer::<CipherSuite>::new(&mut server_rng);
-//! # let server_evaluate_result = server.evaluate(
+//! # let message = server.evaluate(
 //! #     &client_blind_result.message,
 //! #     None,
 //! # ).expect("Unable to perform server evaluate");
 //! let client_finalize_result = client_blind_result
 //!     .state
-//!     .finalize(b"input", &server_evaluate_result.message, None)
+//!     .finalize(b"input", &message, None)
 //!     .expect("Unable to perform client finalization");
 //!
 //! println!("VOPRF output: {:?}", client_finalize_result.to_vec());
@@ -479,7 +478,12 @@
 
 #![deny(unsafe_code)]
 #![no_std]
-#![warn(clippy::cargo, clippy::missing_errors_doc, missing_docs)]
+#![warn(
+    clippy::cargo,
+    clippy::missing_errors_doc,
+    missing_debug_implementations,
+    missing_docs
+)]
 #![allow(clippy::multiple_crate_versions)]
 
 #[cfg(any(feature = "alloc", test))]
@@ -513,8 +517,9 @@ pub use crate::serialization::{
 pub use crate::voprf::VerifiableServerBatchEvaluateResult;
 pub use crate::voprf::{
     BlindedElement, EvaluationElement, Mode, NonVerifiableClient, NonVerifiableClientBlindResult,
-    NonVerifiableServer, NonVerifiableServerEvaluateResult, PreparedEvaluationElement,
-    PreparedTscalar, Proof, VerifiableClient, VerifiableClientBatchFinalizeResult,
-    VerifiableClientBlindResult, VerifiableServer, VerifiableServerBatchEvaluateFinishResult,
-    VerifiableServerBatchEvaluatePrepareResult, VerifiableServerEvaluateResult,
+    NonVerifiableServer, PreparedEvaluationElement, PreparedTscalar, Proof, VerifiableClient,
+    VerifiableClientBatchFinalizeResult, VerifiableClientBlindResult, VerifiableServer,
+    VerifiableServerBatchEvaluateFinishResult, VerifiableServerBatchEvaluateFinishedMessages,
+    VerifiableServerBatchEvaluatePrepareResult,
+    VerifiableServerBatchEvaluatePreparedEvaluationElements, VerifiableServerEvaluateResult,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,6 +492,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "serde")]
+extern crate serde_ as serde;
+
 mod ciphersuite;
 mod error;
 mod group;

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -240,14 +240,14 @@ where
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let server = NonVerifiableServer::<CS>::new_with_key(&parameters.sksm)?;
-            let server_result = server.evaluate(
+            let message = server.evaluate(
                 &BlindedElement::deserialize(&parameters.blinded_element[i])?,
                 Some(&parameters.info),
             )?;
 
             assert_eq!(
                 &parameters.evaluation_element[i],
-                &server_result.message.serialize().as_slice()
+                &message.serialize().as_slice()
             );
         }
     }

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -13,7 +13,7 @@ use core::ops::Add;
 use digest::core_api::BlockSizeUser;
 use digest::OutputSizeUser;
 use generic_array::typenum::{IsLess, IsLessOrEqual, Sum, U256};
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::ArrayLength;
 use json::JsonValue;
 
 use crate::tests::mock_rng::CycleRng;
@@ -183,9 +183,7 @@ where
 {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
-            let blind = CS::Group::deserialize_scalar(&GenericArray::clone_from_slice(
-                &parameters.blind[i],
-            ))?;
+            let blind = CS::Group::deserialize_scalar(&parameters.blind[i])?;
             let client_result = NonVerifiableClient::<CS>::deterministic_blind_unchecked(
                 &parameters.input[i],
                 blind,
@@ -212,9 +210,7 @@ where
 {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
-            let blind = CS::Group::deserialize_scalar(&GenericArray::clone_from_slice(
-                &parameters.blind[i],
-            ))?;
+            let blind = CS::Group::deserialize_scalar(&parameters.blind[i])?;
             let client_blind_result =
                 VerifiableClient::<CS>::deterministic_blind_unchecked(&parameters.input[i], blind)?;
 
@@ -306,7 +302,7 @@ where
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let client = NonVerifiableClient::<CS>::from_blind(CS::Group::deserialize_scalar(
-                &GenericArray::clone_from_slice(&parameters.blind[i]),
+                &parameters.blind[i],
             )?);
 
             let client_finalize_result = client.finalize(
@@ -330,12 +326,8 @@ where
         let mut clients = vec![];
         for i in 0..parameters.input.len() {
             let client = VerifiableClient::<CS>::from_blind_and_element(
-                CS::Group::deserialize_scalar(&GenericArray::clone_from_slice(
-                    &parameters.blind[i],
-                ))?,
-                CS::Group::deserialize_elem(&GenericArray::clone_from_slice(
-                    &parameters.blinded_element[i],
-                ))?,
+                CS::Group::deserialize_scalar(&parameters.blind[i])?,
+                CS::Group::deserialize_elem(&parameters.blinded_element[i])?,
             );
             clients.push(client.clone());
         }
@@ -351,7 +343,7 @@ where
             &clients,
             &messages,
             &Proof::deserialize(&parameters.proof)?,
-            CS::Group::deserialize_elem(GenericArray::from_slice(&parameters.pksm))?,
+            CS::Group::deserialize_elem(&parameters.pksm)?,
             Some(&parameters.info),
         )?;
 

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -20,6 +20,8 @@ use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeEq;
 
+#[cfg(feature = "serde")]
+use crate::serialization::serde::{Element, Scalar};
 use crate::util::{i2osp_2, i2osp_2_array};
 use crate::{CipherSuite, Error, Group, Result};
 
@@ -68,16 +70,14 @@ impl Mode {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Scalar: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Scalar: serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
 pub struct NonVerifiableClient<CS: CipherSuite>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
+    #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) blind: <CS::Group as Group>::Scalar,
 }
 
@@ -89,19 +89,16 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Scalar: serde::Deserialize<'de>, <CS::Group as \
-                       Group>::Elem: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Scalar: serde::Serialize, <CS::Group as Group>::Elem: \
-                     serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
 pub struct VerifiableClient<CS: CipherSuite>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
+    #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) blind: <CS::Group as Group>::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
     pub(crate) blinded_element: <CS::Group as Group>::Elem,
 }
 
@@ -113,16 +110,14 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Scalar: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Scalar: serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
 pub struct NonVerifiableServer<CS: CipherSuite>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
+    #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) sk: <CS::Group as Group>::Scalar,
 }
 
@@ -134,19 +129,16 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Scalar: serde::Deserialize<'de>, <CS::Group as \
-                       Group>::Elem: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Scalar: serde::Serialize, <CS::Group as Group>::Elem: \
-                     serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
 pub struct VerifiableServer<CS: CipherSuite>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
+    #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) sk: <CS::Group as Group>::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
     pub(crate) pk: <CS::Group as Group>::Elem,
 }
 
@@ -158,17 +150,16 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Scalar: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Scalar: serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
 pub struct Proof<CS: CipherSuite>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
+    #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) c_scalar: <CS::Group as Group>::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) s_scalar: <CS::Group as Group>::Scalar,
 }
 
@@ -180,12 +171,12 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Elem: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Elem: serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
-pub struct BlindedElement<CS: CipherSuite>(pub(crate) <CS::Group as Group>::Elem)
+pub struct BlindedElement<CS: CipherSuite>(
+    #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
+    pub(crate)  <CS::Group as Group>::Elem,
+)
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
@@ -198,12 +189,12 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Elem: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Elem: serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
-pub struct EvaluationElement<CS: CipherSuite>(pub(crate) <CS::Group as Group>::Elem)
+pub struct EvaluationElement<CS: CipherSuite>(
+    #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
+    pub(crate)  <CS::Group as Group>::Elem,
+)
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
@@ -834,10 +825,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Elem: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Elem: serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
 pub struct PreparedEvaluationElement<CS: CipherSuite>(EvaluationElement<CS>)
 where
@@ -851,12 +839,12 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(
-        deserialize = "<CS::Group as Group>::Scalar: serde::Deserialize<'de>",
-        serialize = "<CS::Group as Group>::Scalar: serde::Serialize"
-    ))
+    serde(crate = "serde", bound = "")
 )]
-pub struct PreparedTscalar<CS: CipherSuite>(<CS::Group as Group>::Scalar)
+pub struct PreparedTscalar<CS: CipherSuite>(
+    #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
+    <CS::Group as Group>::Scalar,
+)
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -447,7 +447,7 @@ where
     /// [`Error::Deserialization`] if the private key is not a valid point on
     /// the group or zero.
     pub fn new_with_key(private_key_bytes: &[u8]) -> Result<Self> {
-        let sk = CS::Group::deserialize_scalar(private_key_bytes.into())?;
+        let sk = CS::Group::deserialize_scalar(private_key_bytes)?;
         Ok(Self { sk })
     }
 
@@ -531,7 +531,7 @@ where
     /// [`Error::Deserialization`] if the private key is not a valid point on
     /// the group or zero.
     pub fn new_with_key(key: &[u8]) -> Result<Self> {
-        let sk = CS::Group::deserialize_scalar(key.into())?;
+        let sk = CS::Group::deserialize_scalar(key)?;
         let pk = CS::Group::base_elem() * &sk;
         Ok(Self { sk, pk })
     }

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -707,6 +707,52 @@ where
     }
 }
 
+impl<CS: CipherSuite> BlindedElement<CS>
+where
+    <CS::Hash as OutputSizeUser>::OutputSize:
+        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
+{
+    #[cfg(feature = "danger")]
+    /// Creates a [BlindedElement] from a raw group element.
+    ///
+    /// # Caution
+    ///
+    /// This should be used with caution, since it does not perform any checks
+    /// on the validity of the value itself!
+    pub fn from_value_unchecked(value: <CS::Group as Group>::Elem) -> Self {
+        Self(value)
+    }
+
+    #[cfg(feature = "danger")]
+    /// Exposes the internal value
+    pub fn value(&self) -> <CS::Group as Group>::Elem {
+        self.0
+    }
+}
+
+impl<CS: CipherSuite> EvaluationElement<CS>
+where
+    <CS::Hash as OutputSizeUser>::OutputSize:
+        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
+{
+    #[cfg(feature = "danger")]
+    /// Creates an [EvaluationElement] from a raw group element.
+    ///
+    /// # Caution
+    ///
+    /// This should be used with caution, since it does not perform any checks
+    /// on the validity of the value itself!
+    pub fn from_value_unchecked(value: <CS::Group as Group>::Elem) -> Self {
+        Self(value)
+    }
+
+    #[cfg(feature = "danger")]
+    /// Exposes the internal value
+    pub fn value(&self) -> <CS::Group as Group>::Elem {
+        self.0
+    }
+}
+
 /////////////////////////
 // Convenience Structs //
 //==================== //
@@ -866,56 +912,10 @@ where
     pub proof: Proof<CS>,
 }
 
-///////////////////////////////////////////////
-// Inner functions and Trait Implementations //
-// ========================================= //
-///////////////////////////////////////////////
-
-impl<CS: CipherSuite> BlindedElement<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
-    #[cfg(feature = "danger")]
-    /// Creates a [BlindedElement] from a raw group element.
-    ///
-    /// # Caution
-    ///
-    /// This should be used with caution, since it does not perform any checks
-    /// on the validity of the value itself!
-    pub fn from_value_unchecked(value: <CS::Group as Group>::Elem) -> Self {
-        Self(value)
-    }
-
-    #[cfg(feature = "danger")]
-    /// Exposes the internal value
-    pub fn value(&self) -> <CS::Group as Group>::Elem {
-        self.0
-    }
-}
-
-impl<CS: CipherSuite> EvaluationElement<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
-    #[cfg(feature = "danger")]
-    /// Creates an [EvaluationElement] from a raw group element.
-    ///
-    /// # Caution
-    ///
-    /// This should be used with caution, since it does not perform any checks
-    /// on the validity of the value itself!
-    pub fn from_value_unchecked(value: <CS::Group as Group>::Elem) -> Self {
-        Self(value)
-    }
-
-    #[cfg(feature = "danger")]
-    /// Exposes the internal value
-    pub fn value(&self) -> <CS::Group as Group>::Elem {
-        self.0
-    }
-}
+/////////////////////
+// Inner functions //
+// =============== //
+/////////////////////
 
 type BlindResult<C> = (
     <<C as CipherSuite>::Group as Group>::Scalar,


### PR DESCRIPTION
Builds on #55.

- Implement all Rust traits for `Ristretto255`.
- Remove `NonVerifiableServerEvaluateResult` as it was holding only one type.
- Apply `warn(missing_debug_implementations)` and implement `Debug` on all public types.
- Remove leftover `copy` methods now that we are compiling without `alloc`.
- Implement all Rust traits for `PreparedEvaluationElement` and `PreparedTscalar`.
- Introduce more concrete types for complex returned `Iterator`s in the public API.
- Check for zero scalars during `Evaluate` according to the spec.
- Move de/serialization of elements and scalars from `GenericArray`s to slices.
- Fix `new_with_key` would panic if bytes don't have the right length.
- Fix `serde` de/serialization to use the checked variants in `Group`.