### PR TITLE
#58 review

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.3.0"
 [features]
 alloc = []
 danger = []
-default = ["ristretto255-ciphersuite", "ristretto255-u64", "serde", "std"]
+default = ["ristretto255-ciphersuite", "ristretto255-u64", "serde"]
 ristretto255 = ["generic-array/more_lengths"]
 ristretto255-ciphersuite = ["ristretto255", "sha2"]
 ristretto255-fiat-u32 = ["curve25519-dalek/fiat_u32_backend", "ristretto255"]
@@ -26,7 +26,6 @@ serde = ["generic-array/serde", "serde_"]
 std = ["alloc"]
 
 [dependencies]
-hex = "0.4"
 curve25519-dalek = { version = "3", default-features = false, optional = true }
 derive-where = { version = "=1.0.0-rc.2", features = ["zeroize-on-drop"] }
 digest = "0.10"

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,22 +15,20 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 /// Represents an error in the manipulation of internal cryptographic data
 #[derive(Clone, Copy, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Error {
+    /// Size of info is longer then [`u16::MAX`].
+    Info,
     /// Size of input is empty or longer then [`u16::MAX`].
     Input,
-    /// Size of info is longer then `u16::MAX - 21`.
-    Info,
+    /// Size of info and seed together are longer then `u16::MAX - 3`.
+    DeriveKeyPair,
     /// Failure to deserialize bytes
     Deserialization,
     /// Batched items are more then [`u16::MAX`] or length don't match.
     Batch,
     /// In verifiable mode, occurs when the proof failed to verify
     ProofVerification,
-    /// Size of seed is longer then [`u16::MAX`].
-    Seed,
     /// The protocol has failed and can't be completed.
     Protocol,
-    /// Issue with deriving a keypair
-    DeriveKeyPair,
 }
 
 /// Only used to implement [`Group`](crate::Group).

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -15,7 +15,6 @@ use core::ops::{Add, Mul, Sub};
 
 use digest::core_api::BlockSizeUser;
 use digest::OutputSizeUser;
-use generic_array::sequence::Concat;
 use generic_array::typenum::{IsLess, IsLessOrEqual, U256};
 use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
@@ -24,7 +23,6 @@ pub use ristretto::Ristretto255;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
-use crate::util::Mode;
 use crate::{CipherSuite, InternalError, Result};
 
 pub(crate) const STR_HASH_TO_SCALAR: [u8; 13] = *b"HashToScalar-";
@@ -61,7 +59,7 @@ pub trait Group {
     /// then [`u16::MAX`].
     fn hash_to_curve<CS: CipherSuite>(
         input: &[&[u8]],
-        mode: Mode,
+        dst: &[u8],
     ) -> Result<Self::Elem, InternalError>
     where
         <CS::Hash as OutputSizeUser>::OutputSize:
@@ -73,26 +71,6 @@ pub trait Group {
     /// [`Error::Input`](crate::Error::Input) if the `input` is empty or longer
     /// then [`u16::MAX`].
     fn hash_to_scalar<CS: CipherSuite>(
-        input: &[&[u8]],
-        mode: Mode,
-    ) -> Result<Self::Scalar, InternalError>
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
-        let dst = GenericArray::from(STR_HASH_TO_SCALAR)
-            .concat(crate::util::create_context_string::<CS>(mode));
-
-        Self::hash_to_scalar_with_dst::<CS>(input, &dst)
-    }
-
-    /// Hashes a slice of pseudo-random bytes to a scalar, allowing for
-    /// specifying a custom domain separation tag (DST)
-    ///
-    /// # Errors
-    /// [`Error::Input`](crate::Error::Input) if the `input` is empty or longer
-    /// then [`u16::MAX`].
-    fn hash_to_scalar_with_dst<CS: CipherSuite>(
         input: &[&[u8]],
         dst: &[u8],
     ) -> Result<Self::Scalar, InternalError>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,10 +106,8 @@
 //! # ).expect("Unable to construct client");
 //! # use voprf::OprfServer;
 //! # let mut server_rng = OsRng;
-//! # let server = OprfServer::<CipherSuite>::new(&mut server_rng);
-//! let server_evaluate_result = server
-//!     .evaluate(&client_blind_result.message)
-//!     .expect("Unable to perform server evaluate");
+//! # let server = OprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
+//! let server_evaluate_result = server.evaluate(&client_blind_result.message);
 //! ```
 //!
 //! ### Client Finalization
@@ -133,14 +131,11 @@
 //! # ).expect("Unable to construct client");
 //! # use voprf::OprfServer;
 //! # let mut server_rng = OsRng;
-//! # let server = OprfServer::<CipherSuite>::new(&mut server_rng);
-//! # let message = server.evaluate(
-//! #     &client_blind_result.message,
-//! #     None,
-//! # ).expect("Unable to perform server evaluate");
+//! # let server = OprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
+//! # let message = server.evaluate(&client_blind_result.message);
 //! let client_finalize_result = client_blind_result
 //!     .state
-//!     .finalize(b"input", &message, None)
+//!     .finalize(b"input", &message)
 //!     .expect("Unable to perform client finalization");
 //!
 //! println!("VOPRF output: {:?}", client_finalize_result.to_vec());
@@ -174,7 +169,7 @@
 //! use voprf::VoprfServer;
 //!
 //! let mut server_rng = OsRng;
-//! let server = VoprfServer::<CipherSuite>::new(&mut server_rng);
+//! let server = VoprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
 //!
 //! // To be sent to the client
 //! println!("Server public key: {:?}", server.get_public_key());
@@ -219,7 +214,7 @@
 //! # type CipherSuite = voprf::Ristretto255;
 //! # #[cfg(not(feature = "ristretto255"))]
 //! # type CipherSuite = p256::NistP256;
-//! # use voprf::VoprfClient;
+//! # use voprf::{VoprfServerEvaluateResult, VoprfClient};
 //! # use rand::{rngs::OsRng, RngCore};
 //! #
 //! # let mut client_rng = OsRng;
@@ -229,10 +224,9 @@
 //! # ).expect("Unable to construct client");
 //! # use voprf::VoprfServer;
 //! # let mut server_rng = OsRng;
-//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng);
-//! let server_evaluate_result = server
-//!     .evaluate(&mut server_rng, &client_blind_result.message, None)
-//!     .expect("Unable to perform server evaluate");
+//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
+//! let VoprfServerEvaluateResult { message, proof } =
+//!     server.evaluate(&mut server_rng, &client_blind_result.message);
 //! ```
 //!
 //! ### Client Finalization
@@ -257,12 +251,11 @@
 //! # ).expect("Unable to construct client");
 //! # use voprf::VoprfServer;
 //! # let mut server_rng = OsRng;
-//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng);
+//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
 //! # let server_evaluate_result = server.evaluate(
 //! #     &mut server_rng,
 //! #     &client_blind_result.message,
-//! #     None,
-//! # ).expect("Unable to perform server evaluate");
+//! # );
 //! let client_finalize_result = client_blind_result
 //!     .state
 //!     .finalize(
@@ -270,7 +263,6 @@
 //!         &server_evaluate_result.message,
 //!         &server_evaluate_result.proof,
 //!         server.get_public_key(),
-//!         None,
 //!     )
 //!     .expect("Unable to perform client finalization");
 //!
@@ -323,7 +315,7 @@
 //! # type CipherSuite = voprf::Ristretto255;
 //! # #[cfg(not(feature = "ristretto255"))]
 //! # type CipherSuite = p256::NistP256;
-//! # use voprf::{VoprfServerBatchEvaluatePrepareResult, VoprfServerBatchEvaluateFinishResult, VoprfClient};
+//! # use voprf::{VoprfServerBatchEvaluateFinishResult, VoprfClient};
 //! # use rand::{rngs::OsRng, RngCore};
 //! #
 //! # let mut client_rng = OsRng;
@@ -339,15 +331,11 @@
 //! # }
 //! # use voprf::VoprfServer;
 //! let mut server_rng = OsRng;
-//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng);
-//! let VoprfServerBatchEvaluatePrepareResult {
-//!     prepared_evaluation_elements,
-//!     t,
-//! } = server
-//!     .batch_evaluate_prepare(client_messages.iter(), None)
-//!     .expect("Unable to perform server batch evaluate");
+//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
+//! let prepared_evaluation_elements = server.batch_evaluate_prepare(client_messages.iter());
 //! let prepared_elements: Vec<_> = prepared_evaluation_elements.collect();
-//! let VoprfServerBatchEvaluateFinishResult { messages, proof } = VoprfServer::batch_evaluate_finish(&mut server_rng, client_messages.iter(), &prepared_elements, &t)
+//! let VoprfServerBatchEvaluateFinishResult { messages, proof } = server
+//!     .batch_evaluate_finish(&mut server_rng, client_messages.iter(), &prepared_elements)
 //!     .expect("Unable to perform server batch evaluate");
 //! let messages: Vec<_> = messages.collect();
 //! ```
@@ -377,9 +365,9 @@
 //! # }
 //! # use voprf::VoprfServer;
 //! let mut server_rng = OsRng;
-//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng);
+//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
 //! let VoprfServerBatchEvaluateResult { messages, proof } = server
-//!     .batch_evaluate(&mut server_rng, &client_messages, None)
+//!     .batch_evaluate(&mut server_rng, &client_messages)
 //!     .expect("Unable to perform server batch evaluate");
 //! # }
 //! ```
@@ -411,9 +399,9 @@
 //! # }
 //! # use voprf::VoprfServer;
 //! # let mut server_rng = OsRng;
-//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng);
+//! # let server = VoprfServer::<CipherSuite>::new(&mut server_rng).unwrap();
 //! # let VoprfServerBatchEvaluateResult { messages, proof } = server
-//! #     .batch_evaluate(&mut server_rng, &client_messages, None)
+//! #     .batch_evaluate(&mut server_rng, &client_messages)
 //! #     .expect("Unable to perform server batch evaluate");
 //! let client_batch_finalize_result = VoprfClient::batch_finalize(
 //!     &[b"input"; 10],
@@ -421,7 +409,6 @@
 //!     &messages,
 //!     &proof,
 //!     server.get_public_key(),
-//!     None,
 //! )
 //! .expect("Unable to perform client batch finalization")
 //! .collect::<Vec<_>>();
@@ -515,15 +502,22 @@ pub use crate::group::Group;
 #[cfg(feature = "ristretto255")]
 pub use crate::group::Ristretto255;
 pub use crate::oprf::{OprfClient, OprfClientBlindResult, OprfServer};
-pub use crate::poprf::{PoprfClient, PoprfServer, PoprfServerBatchEvaluateResult};
-pub use crate::serialization::{
-    BlindedElementLen, EvaluationElementLen, OprfClientLen, OprfServerLen, ProofLen,
-    VoprfClientLen, VoprfServerLen,
+#[cfg(feature = "alloc")]
+pub use crate::poprf::PoprfServerBatchEvaluateResult;
+pub use crate::poprf::{
+    PoprfClient, PoprfClientBatchFinalizeResult, PoprfPreparedTweak, PoprfServer,
+    PoprfServerBatchEvaluateFinishResult, PoprfServerBatchEvaluateFinishedMessages,
+    PoprfServerBatchEvaluatePrepareResult, PoprfServerBatchEvaluatePreparedEvaluationElements,
 };
-pub use crate::util::{BlindedElement, EvaluationElement, Mode, Proof};
+pub use crate::serialization::{
+    BlindedElementLen, EvaluationElementLen, OprfClientLen, OprfServerLen, PoprfClientLen,
+    PoprfServerLen, ProofLen, VoprfClientLen, VoprfServerLen,
+};
+pub use crate::util::{BlindedElement, EvaluationElement, Mode, PreparedEvaluationElement, Proof};
 #[cfg(feature = "alloc")]
 pub use crate::voprf::VoprfServerBatchEvaluateResult;
 pub use crate::voprf::{
     VoprfClient, VoprfClientBatchFinalizeResult, VoprfClientBlindResult, VoprfServer,
-    VoprfServerEvaluateResult,
+    VoprfServerBatchEvaluateFinishResult, VoprfServerBatchEvaluateFinishedMessages,
+    VoprfServerBatchEvaluatePreparedEvaluationElements, VoprfServerEvaluateResult,
 };

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -52,7 +52,7 @@ where
     }
 }
 
-/// Length of [`VerifiableClient`] in bytes for serialization.
+/// Length of [`VoprfClient`] in bytes for serialization.
 pub type VoprfClientLen<CS> = Sum<
     <<CS as CipherSuite>::Group as Group>::ScalarLen,
     <<CS as CipherSuite>::Group as Group>::ElemLen,
@@ -90,16 +90,22 @@ where
     }
 }
 
+/// Length of [`PoprfClient`] in bytes for serialization.
+pub type PoprfClientLen<CS> = Sum<
+    <<CS as CipherSuite>::Group as Group>::ScalarLen,
+    <<CS as CipherSuite>::Group as Group>::ElemLen,
+>;
+
 impl<CS: CipherSuite> PoprfClient<CS>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
     /// Serialization into bytes
-    pub fn serialize(&self) -> GenericArray<u8, VoprfClientLen<CS>>
+    pub fn serialize(&self) -> GenericArray<u8, PoprfClientLen<CS>>
     where
         <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        VoprfClientLen<CS>: ArrayLength<u8>,
+        PoprfClientLen<CS>: ArrayLength<u8>,
     {
         <CS::Group as Group>::serialize_scalar(self.blind)
             .concat(<CS::Group as Group>::serialize_elem(self.blinded_element))
@@ -148,7 +154,7 @@ where
     }
 }
 
-/// Length of [`VerifiableServer`] in bytes for serialization.
+/// Length of [`VoprfServer`] in bytes for serialization.
 pub type VoprfServerLen<CS> = Sum<
     <<CS as CipherSuite>::Group as Group>::ScalarLen,
     <<CS as CipherSuite>::Group as Group>::ElemLen,
@@ -182,16 +188,22 @@ where
     }
 }
 
+/// Length of [`PoprfServer`] in bytes for serialization.
+pub type PoprfServerLen<CS> = Sum<
+    <<CS as CipherSuite>::Group as Group>::ScalarLen,
+    <<CS as CipherSuite>::Group as Group>::ElemLen,
+>;
+
 impl<CS: CipherSuite> PoprfServer<CS>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
     /// Serialization into bytes
-    pub fn serialize(&self) -> GenericArray<u8, VoprfServerLen<CS>>
+    pub fn serialize(&self) -> GenericArray<u8, PoprfServerLen<CS>>
     where
         <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        VoprfServerLen<CS>: ArrayLength<u8>,
+        PoprfServerLen<CS>: ArrayLength<u8>,
     {
         CS::Group::serialize_scalar(self.sk).concat(CS::Group::serialize_elem(self.pk))
     }


### PR DESCRIPTION
This builds on top of #58.

- Remove `hex` from dependencies.
- Revert `std` as `default` feature.
- Correct error documentation.
- Revert old change of passing `Mode` into `hash_to_curve` and `hash_to_scalar`.
- Fix documentation tests.
- Fix documentation links.
- Introduce no alloc version of `batch_evaluate` for POPRF and VOPRF.
- Fix wrong errors.
- Fix returning `Result` instead of panicking when using `derive_key_pair`.
- Change public functions to take iterators instead of slices when batching.
- Remove some unnecessarily returned `Result`s.
- Improve `derive_keypair`.
- Remove `i2osp_1`.
- Some general code improvements.

Sadly I was unable to make a complete no alloc solution for POPRF despite my hopes mentioned on Slack.
I apologize for this single mega-commit!