### PR TITLE
Update to `curve25519-dalek` pre-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = ["generic-array/serde", "serde_"]
 std = ["alloc"]
 
 [dependencies]
-curve25519-dalek = { version = "3", default-features = false, optional = true }
+curve25519-dalek = { version = "=4.0.0-pre.1", default-features = false, optional = true }
 derive-where = { version = "=1.0.0-rc.2", features = ["zeroize-on-drop"] }
 digest = "0.10"
 displaydoc = { version = "0.2", default-features = false }


### PR DESCRIPTION
While working on novifinancial/opaque-ke#261 I realized that the current version of `x25519-dalek` is not compatible with RustCrypto because it pins for example `zeroize` to an old version. Cargo doesn't not allow the same major version of a dependency to exist in the same dependency tree.

After some research I pretty much established that the pre-releases are not really experimental but are just semver-incompatible versions of the stable versions with updated dependencies. Basically it fits our bill.

In `opaque-ke` we will pull the pre-release versions of `curve25519-dalek` and `x25519-dalek` and won't have tons of duplicate dependencies this way.