### PR TITLE
General improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ std = ["alloc"]
 
 [dependencies]
 curve25519-dalek = { version = "=4.0.0-pre.1", default-features = false, optional = true }
-derive-where = { version = "=1.0.0-rc.2", features = ["zeroize-on-drop"] }
+derive-where = { version = "=1.0.0-rc.3", features = ["zeroize-on-drop"] }
 digest = "0.10"
 displaydoc = { version = "0.2", default-features = false }
 elliptic-curve = { version = "=0.12.0-pre.1", features = [

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-//! Helper functions
+//! Common functionality between multiple OPRF modes.
 
 use core::convert::TryFrom;
 
@@ -18,7 +18,6 @@ use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeEq;
 
-use crate::group::{STR_HASH_TO_GROUP, STR_HASH_TO_SCALAR};
 #[cfg(feature = "serde")]
 use crate::serialization::serde::{Element, Scalar};
 use crate::{CipherSuite, Error, Group, InternalError, Result};
@@ -35,6 +34,8 @@ pub(crate) const STR_COMPOSITE: [u8; 9] = *b"Composite";
 pub(crate) const STR_CHALLENGE: [u8; 9] = *b"Challenge";
 pub(crate) const STR_INFO: [u8; 4] = *b"Info";
 pub(crate) const STR_VOPRF: [u8; 8] = *b"VOPRF09-";
+pub(crate) const STR_HASH_TO_SCALAR: [u8; 13] = *b"HashToScalar-";
+pub(crate) const STR_HASH_TO_GROUP: [u8; 12] = *b"HashToGroup-";
 
 /// Determines the mode of operation (either base mode or verifiable mode). This
 /// is only used for custom implementations for [`Group`].
@@ -440,74 +441,4 @@ pub(crate) fn i2osp_2_array<L: ArrayLength<u8> + IsLess<U256>>(
     _: &GenericArray<u8, L>,
 ) -> GenericArray<u8, U2> {
     L::U16.to_be_bytes().into()
-}
-
-#[cfg(test)]
-mod unit_tests {
-    use proptest::collection::vec;
-    use proptest::prelude::*;
-
-    use crate::{
-        BlindedElement, EvaluationElement, OprfClient, OprfServer, PoprfClient, PoprfServer, Proof,
-        VoprfClient, VoprfServer,
-    };
-
-    macro_rules! test_deserialize {
-        ($item:ident, $bytes:ident) => {
-            #[cfg(feature = "ristretto255")]
-            {
-                let _ = $item::<crate::Ristretto255>::deserialize(&$bytes[..]);
-            }
-
-            let _ = $item::<p256::NistP256>::deserialize(&$bytes[..]);
-        };
-    }
-
-    proptest! {
-        #[test]
-        fn test_nocrash_oprf_client(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(OprfClient, bytes);
-        }
-
-        #[test]
-        fn test_nocrash_voprf_client(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(VoprfClient, bytes);
-        }
-
-        #[test]
-        fn test_nocrash_poprf_client(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(PoprfClient, bytes);
-        }
-
-        #[test]
-        fn test_nocrash_oprf_server(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(OprfServer, bytes);
-        }
-
-        #[test]
-        fn test_nocrash_voprf_server(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(VoprfServer, bytes);
-        }
-
-        #[test]
-        fn test_nocrash_poprf_server(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(PoprfServer, bytes);
-        }
-
-
-        #[test]
-        fn test_nocrash_blinded_element(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(BlindedElement, bytes);
-        }
-
-        #[test]
-        fn test_nocrash_evaluation_element(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(EvaluationElement, bytes);
-        }
-
-        #[test]
-        fn test_nocrash_proof(bytes in vec(any::<u8>(), 0..200)) {
-            test_deserialize!(Proof, bytes);
-        }
-    }
 }

--- a/src/group/elliptic_curve.rs
+++ b/src/group/elliptic_curve.rs
@@ -23,7 +23,7 @@ use crate::{Error, InternalError, Result};
 impl<C> Group for C
 where
     C: GroupDigest,
-    ProjectivePoint<Self>: CofactorGroup,
+    ProjectivePoint<Self>: CofactorGroup + ToEncodedPoint<Self>,
     FieldSize<Self>: ModulusSize,
     AffinePoint<Self>: FromEncodedPoint<Self> + ToEncodedPoint<Self>,
     Scalar<Self>: FromOkm,
@@ -65,8 +65,7 @@ where
     }
 
     fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
-        let point: AffinePoint<Self> = elem.into();
-        let bytes = point.to_encoded_point(true);
+        let bytes = elem.to_encoded_point(true);
         let bytes = bytes.as_bytes();
         let mut result = GenericArray::default();
         result[..bytes.len()].copy_from_slice(bytes);

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -14,7 +14,7 @@ mod ristretto;
 use core::ops::{Add, Mul, Sub};
 
 use digest::core_api::BlockSizeUser;
-use digest::OutputSizeUser;
+use digest::Digest;
 use generic_array::typenum::{IsLess, IsLessOrEqual, U256};
 use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
@@ -23,7 +23,7 @@ pub use ristretto::Ristretto255;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
-use crate::{CipherSuite, InternalError, Result};
+use crate::{InternalError, Result};
 
 pub(crate) const STR_HASH_TO_SCALAR: [u8; 13] = *b"HashToScalar-";
 pub(crate) const STR_HASH_TO_GROUP: [u8; 12] = *b"HashToGroup-";
@@ -57,26 +57,20 @@ pub trait Group {
     /// # Errors
     /// [`Error::Input`](crate::Error::Input) if the `input` is empty or longer
     /// then [`u16::MAX`].
-    fn hash_to_curve<CS: CipherSuite>(
-        input: &[&[u8]],
-        dst: &[u8],
-    ) -> Result<Self::Elem, InternalError>
+    fn hash_to_curve<H>(input: &[&[u8]], dst: &[u8]) -> Result<Self::Elem, InternalError>
     where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
+        H: Digest + BlockSizeUser,
+        H::OutputSize: IsLess<U256> + IsLessOrEqual<H::BlockSize>;
 
     /// Hashes a slice of pseudo-random bytes to a scalar
     ///
     /// # Errors
     /// [`Error::Input`](crate::Error::Input) if the `input` is empty or longer
     /// then [`u16::MAX`].
-    fn hash_to_scalar<CS: CipherSuite>(
-        input: &[&[u8]],
-        dst: &[u8],
-    ) -> Result<Self::Scalar, InternalError>
+    fn hash_to_scalar<H>(input: &[&[u8]], dst: &[u8]) -> Result<Self::Scalar, InternalError>
     where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
+        H: Digest + BlockSizeUser,
+        H::OutputSize: IsLess<U256> + IsLessOrEqual<H::BlockSize>;
 
     /// Get the base point for the group
     fn base_elem() -> Self::Elem;

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -25,9 +25,6 @@ use zeroize::Zeroize;
 
 use crate::{InternalError, Result};
 
-pub(crate) const STR_HASH_TO_SCALAR: [u8; 13] = *b"HashToScalar-";
-pub(crate) const STR_HASH_TO_GROUP: [u8; 12] = *b"HashToGroup-";
-
 /// A prime-order subgroup of a base field (EC, prime-order field ...). This
 /// subgroup is noted additively — as in the draft RFC — in this trait.
 pub trait Group {

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -90,6 +90,10 @@ impl Group for Ristretto255 {
     }
 
     fn deserialize_elem(element_bits: &[u8]) -> Result<Self::Elem> {
+        if element_bits.len() != 32 {
+            return Err(Error::Deserialization);
+        }
+
         CompressedRistretto::from_slice(element_bits)
             .decompress()
             .filter(|point| point != &RistrettoPoint::identity())

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -98,11 +98,7 @@ impl Group for Ristretto255 {
 
     fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
         loop {
-            let scalar = {
-                let mut scalar_bytes = [0u8; 64];
-                rng.fill_bytes(&mut scalar_bytes);
-                Scalar::from_bytes_mod_order_wide(&scalar_bytes)
-            };
+            let scalar = Scalar::random(rng);
 
             if scalar != Scalar::zero() {
                 break scalar;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,12 +483,12 @@ extern crate std;
 extern crate serde_ as serde;
 
 mod ciphersuite;
+mod common;
 mod error;
 mod group;
 mod oprf;
 mod poprf;
 mod serialization;
-mod util;
 mod voprf;
 
 #[cfg(test)]
@@ -497,6 +497,9 @@ mod tests;
 // Exports
 
 pub use crate::ciphersuite::CipherSuite;
+pub use crate::common::{
+    BlindedElement, EvaluationElement, Mode, PreparedEvaluationElement, Proof,
+};
 pub use crate::error::{Error, InternalError, Result};
 pub use crate::group::Group;
 #[cfg(feature = "ristretto255")]
@@ -513,7 +516,6 @@ pub use crate::serialization::{
     BlindedElementLen, EvaluationElementLen, OprfClientLen, OprfServerLen, PoprfClientLen,
     PoprfServerLen, ProofLen, VoprfClientLen, VoprfServerLen,
 };
-pub use crate::util::{BlindedElement, EvaluationElement, Mode, PreparedEvaluationElement, Proof};
 #[cfg(feature = "alloc")]
 pub use crate::voprf::VoprfServerBatchEvaluateResult;
 pub use crate::voprf::{

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -294,7 +294,7 @@ mod tests {
             IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
     {
         let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(create_context_string::<CS>(mode));
-        let point = CS::Group::hash_to_curve::<CS>(&[input], &dst).unwrap();
+        let point = CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst).unwrap();
 
         let res = point * &key;
 
@@ -335,7 +335,7 @@ mod tests {
 
         let dst =
             GenericArray::from(STR_HASH_TO_GROUP).concat(create_context_string::<CS>(Mode::Oprf));
-        let point = CS::Group::hash_to_curve::<CS>(&[&input], &dst).unwrap();
+        let point = CS::Group::hash_to_curve::<CS::Hash>(&[&input], &dst).unwrap();
         let res2 = finalize_after_unblind::<CS, _, _>(iter::once((input.as_ref(), point)), &[])
             .next()
             .unwrap()

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -16,12 +16,12 @@ use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U256};
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "serde")]
-use crate::serialization::serde::Scalar;
-use crate::util::{
+use crate::common::{
     derive_keypair, deterministic_blind_unchecked, i2osp_2, BlindedElement, EvaluationElement,
     Mode, STR_FINALIZE,
 };
+#[cfg(feature = "serde")]
+use crate::serialization::serde::Scalar;
 use crate::{CipherSuite, Error, Group, Result};
 
 ///////////////
@@ -279,8 +279,7 @@ mod tests {
     use rand::rngs::OsRng;
 
     use super::*;
-    use crate::group::STR_HASH_TO_GROUP;
-    use crate::util::create_context_string;
+    use crate::common::{create_context_string, STR_HASH_TO_GROUP};
     use crate::Group;
 
     fn prf<CS: CipherSuite>(

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -17,8 +17,8 @@ use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::common::{
-    derive_keypair, deterministic_blind_unchecked, i2osp_2, BlindedElement, EvaluationElement,
-    Mode, STR_FINALIZE,
+    derive_key, deterministic_blind_unchecked, i2osp_2, BlindedElement, EvaluationElement, Mode,
+    STR_FINALIZE,
 };
 #[cfg(feature = "serde")]
 use crate::serialization::serde::Scalar;
@@ -189,7 +189,7 @@ where
     ///   then `u16::MAX - 3`.
     /// - [`Error::Protocol`] if the protocol fails and can't be completed.
     pub fn new_from_seed(seed: &[u8], info: &[u8]) -> Result<Self> {
-        let (sk, _) = derive_keypair::<CS>(seed, info, Mode::Oprf)?;
+        let sk = derive_key::<CS>(seed, info, Mode::Oprf)?;
         Ok(Self { sk })
     }
 

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -596,7 +596,7 @@ where
     let dst =
         GenericArray::from(STR_HASH_TO_SCALAR).concat(create_context_string::<CS>(Mode::Poprf));
     // This can't fail, the size of the `input` is known.
-    let m = CS::Group::hash_to_scalar::<CS>(&framed_info, &dst).unwrap();
+    let m = CS::Group::hash_to_scalar::<CS::Hash>(&framed_info, &dst).unwrap();
 
     let t = CS::Group::base_elem() * &m;
     let tweaked_key = t + &pk;
@@ -634,7 +634,7 @@ where
     let dst =
         GenericArray::from(STR_HASH_TO_SCALAR).concat(create_context_string::<CS>(Mode::Poprf));
     // This can't fail, the size of the `input` is known.
-    let m = CS::Group::hash_to_scalar::<CS>(&framed_info, &dst).unwrap();
+    let m = CS::Group::hash_to_scalar::<CS::Hash>(&framed_info, &dst).unwrap();
 
     let t = sk + &m;
 
@@ -788,7 +788,7 @@ mod tests {
         let t = compute_tweak::<CS>(key, Some(info)).unwrap();
 
         let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(create_context_string::<CS>(mode));
-        let point = CS::Group::hash_to_curve::<CS>(&[input], &dst).unwrap();
+        let point = CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst).unwrap();
 
         // evaluatedElement = G.ScalarInverse(t) * blindedElement
         let res = point * &CS::Group::invert_scalar(t);
@@ -844,7 +844,7 @@ mod tests {
             let dst = GenericArray::from(STR_HASH_TO_GROUP)
                 .concat(create_context_string::<CS>(Mode::Oprf));
             // Choose a group element that is unlikely to be the right public key
-            CS::Group::hash_to_curve::<CS>(&[b"msg"], &dst).unwrap()
+            CS::Group::hash_to_curve::<CS::Hash>(&[b"msg"], &dst).unwrap()
         };
         let client_finalize_result = client_blind_result.state.finalize(
             input,

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -19,14 +19,13 @@ use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U256};
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
-use crate::group::STR_HASH_TO_SCALAR;
-#[cfg(feature = "serde")]
-use crate::serialization::serde::{Element, Scalar};
-use crate::util::{
+use crate::common::{
     create_context_string, derive_keypair, deterministic_blind_unchecked, generate_proof, i2osp_2,
     verify_proof, BlindedElement, EvaluationElement, Mode, PreparedEvaluationElement, Proof,
-    STR_FINALIZE, STR_INFO,
+    STR_FINALIZE, STR_HASH_TO_SCALAR, STR_INFO,
 };
+#[cfg(feature = "serde")]
+use crate::serialization::serde::{Element, Scalar};
 use crate::{CipherSuite, Error, Group, Result};
 
 ////////////////////////////
@@ -772,7 +771,7 @@ mod tests {
     use rand::rngs::OsRng;
 
     use super::*;
-    use crate::group::STR_HASH_TO_GROUP;
+    use crate::common::STR_HASH_TO_GROUP;
     use crate::Group;
 
     fn prf<CS: CipherSuite>(

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -372,3 +372,73 @@ pub(crate) mod serde {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use proptest::collection::vec;
+    use proptest::prelude::*;
+
+    use crate::{
+        BlindedElement, EvaluationElement, OprfClient, OprfServer, PoprfClient, PoprfServer, Proof,
+        VoprfClient, VoprfServer,
+    };
+
+    macro_rules! test_deserialize {
+        ($item:ident, $bytes:ident) => {
+            #[cfg(feature = "ristretto255")]
+            {
+                let _ = $item::<crate::Ristretto255>::deserialize(&$bytes[..]);
+            }
+
+            let _ = $item::<p256::NistP256>::deserialize(&$bytes[..]);
+        };
+    }
+
+    proptest! {
+        #[test]
+        fn test_nocrash_oprf_client(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(OprfClient, bytes);
+        }
+
+        #[test]
+        fn test_nocrash_voprf_client(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(VoprfClient, bytes);
+        }
+
+        #[test]
+        fn test_nocrash_poprf_client(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(PoprfClient, bytes);
+        }
+
+        #[test]
+        fn test_nocrash_oprf_server(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(OprfServer, bytes);
+        }
+
+        #[test]
+        fn test_nocrash_voprf_server(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(VoprfServer, bytes);
+        }
+
+        #[test]
+        fn test_nocrash_poprf_server(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(PoprfServer, bytes);
+        }
+
+
+        #[test]
+        fn test_nocrash_blinded_element(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(BlindedElement, bytes);
+        }
+
+        #[test]
+        fn test_nocrash_evaluation_element(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(EvaluationElement, bytes);
+        }
+
+        #[test]
+        fn test_nocrash_proof(bytes in vec(any::<u8>(), 0..200)) {
+            test_deserialize!(Proof, bytes);
+        }
+    }
+}

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -43,10 +43,8 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let blind = deserialize_scalar::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let blind = deserialize_scalar::<CS::Group>(&mut input)?;
 
         Ok(Self { blind })
     }
@@ -77,11 +75,9 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let blind = deserialize_scalar::<CS::Group, _>(&mut input)?;
-        let blinded_element = deserialize_elem::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let blind = deserialize_scalar::<CS::Group>(&mut input)?;
+        let blinded_element = deserialize_elem::<CS::Group>(&mut input)?;
 
         Ok(Self {
             blind,
@@ -115,11 +111,9 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let blind = deserialize_scalar::<CS::Group, _>(&mut input)?;
-        let blinded_element = deserialize_elem::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let blind = deserialize_scalar::<CS::Group>(&mut input)?;
+        let blinded_element = deserialize_elem::<CS::Group>(&mut input)?;
 
         Ok(Self {
             blind,
@@ -145,10 +139,8 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let sk = deserialize_scalar::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let sk = deserialize_scalar::<CS::Group>(&mut input)?;
 
         Ok(Self { sk })
     }
@@ -178,11 +170,9 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let sk = deserialize_scalar::<CS::Group, _>(&mut input)?;
-        let pk = deserialize_elem::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let sk = deserialize_scalar::<CS::Group>(&mut input)?;
+        let pk = deserialize_elem::<CS::Group>(&mut input)?;
 
         Ok(Self { sk, pk })
     }
@@ -212,11 +202,9 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let sk = deserialize_scalar::<CS::Group, _>(&mut input)?;
-        let pk = deserialize_elem::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let sk = deserialize_scalar::<CS::Group>(&mut input)?;
+        let pk = deserialize_elem::<CS::Group>(&mut input)?;
 
         Ok(Self { sk, pk })
     }
@@ -247,11 +235,9 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let c_scalar = deserialize_scalar::<CS::Group, _>(&mut input)?;
-        let s_scalar = deserialize_scalar::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let c_scalar = deserialize_scalar::<CS::Group>(&mut input)?;
+        let s_scalar = deserialize_scalar::<CS::Group>(&mut input)?;
 
         Ok(Proof { c_scalar, s_scalar })
     }
@@ -274,10 +260,8 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let value = deserialize_elem::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let value = deserialize_elem::<CS::Group>(&mut input)?;
 
         Ok(Self(value))
     }
@@ -300,27 +284,41 @@ where
     ///
     /// # Errors
     /// [`Error::Deserialization`] if failed to deserialize `input`.
-    pub fn deserialize(input: &[u8]) -> Result<Self> {
-        let mut input = input.iter().copied();
-
-        let value = deserialize_elem::<CS::Group, _>(&mut input)?;
+    pub fn deserialize(mut input: &[u8]) -> Result<Self> {
+        let value = deserialize_elem::<CS::Group>(&mut input)?;
 
         Ok(Self(value))
     }
 }
 
-fn deserialize_elem<G: Group, I: Iterator<Item = u8>>(input: &mut I) -> Result<G::Elem> {
-    let input = input.by_ref().take(G::ElemLen::USIZE);
-    GenericArray::<_, G::ElemLen>::from_exact_iter(input)
-        .ok_or(Error::Deserialization)
-        .and_then(|bytes| G::deserialize_elem(&bytes))
+fn deserialize_elem<G: Group>(input: &mut &[u8]) -> Result<G::Elem> {
+    let input = input
+        .take_ext(G::ElemLen::USIZE)
+        .ok_or(Error::Deserialization)?;
+    G::deserialize_elem(input)
 }
 
-fn deserialize_scalar<G: Group, I: Iterator<Item = u8>>(input: &mut I) -> Result<G::Scalar> {
-    let input = input.by_ref().take(G::ScalarLen::USIZE);
-    GenericArray::<_, G::ScalarLen>::from_exact_iter(input)
-        .ok_or(Error::Deserialization)
-        .and_then(|bytes| G::deserialize_scalar(&bytes))
+fn deserialize_scalar<G: Group>(input: &mut &[u8]) -> Result<G::Scalar> {
+    let input = input
+        .take_ext(G::ScalarLen::USIZE)
+        .ok_or(Error::Deserialization)?;
+    G::deserialize_scalar(input)
+}
+
+trait SliceExt {
+    fn take_ext(self: &mut &Self, take: usize) -> Option<&Self>;
+}
+
+impl<T> SliceExt for [T] {
+    fn take_ext(self: &mut &Self, take: usize) -> Option<&Self> {
+        if take > self.len() {
+            return None;
+        }
+
+        let (front, back) = self.split_at(take);
+        *self = back;
+        Some(front)
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/src/tests/test_cfrg_vectors.rs
+++ b/src/tests/test_cfrg_vectors.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Add;
@@ -60,19 +60,15 @@ fn populate_test_vectors(values: &JsonValue) -> VOPRFTestVectorParameters {
 fn decode(values: &JsonValue, key: &str) -> Vec<u8> {
     values[key]
         .as_str()
-        .and_then(|s| hex::decode(&s.to_string()).ok())
+        .and_then(|s| hex::decode(&s).ok())
         .unwrap_or_default()
 }
 
 fn decode_vec(values: &JsonValue, key: &str) -> Vec<Vec<u8>> {
     let s = values[key].as_str().unwrap();
     let res = match s.contains(',') {
-        true => Some(
-            s.split(',')
-                .map(|x| hex::decode(&x.to_string()).unwrap())
-                .collect(),
-        ),
-        false => Some(vec![hex::decode(&s.to_string()).unwrap()]),
+        true => Some(s.split(',').map(|x| hex::decode(&x).unwrap()).collect()),
+        false => Some(vec![hex::decode(&s).unwrap()]),
     };
     res.unwrap()
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -195,7 +195,7 @@ where
 
     let dst = GenericArray::from(STR_HASH_TO_SCALAR).concat(create_context_string::<CS>(mode));
     // This can't fail, the size of the `input` is known.
-    let c_scalar = CS::Group::hash_to_scalar::<CS>(&h2_input, &dst).unwrap();
+    let c_scalar = CS::Group::hash_to_scalar::<CS::Hash>(&h2_input, &dst).unwrap();
     let s_scalar = r - &(c_scalar * &k);
 
     Ok(Proof { c_scalar, s_scalar })
@@ -255,7 +255,7 @@ where
 
     let dst = GenericArray::from(STR_HASH_TO_SCALAR).concat(create_context_string::<CS>(mode));
     // This can't fail, the size of the `input` is known.
-    let c = CS::Group::hash_to_scalar::<CS>(&h2_input, &dst).unwrap();
+    let c = CS::Group::hash_to_scalar::<CS::Hash>(&h2_input, &dst).unwrap();
 
     match c.ct_eq(&proof.c_scalar).into() {
         true => Ok(()),
@@ -333,7 +333,7 @@ where
 
         let dst = GenericArray::from(STR_HASH_TO_SCALAR).concat(create_context_string::<CS>(mode));
         // This can't fail, the size of the `input` is known.
-        let di = CS::Group::hash_to_scalar::<CS>(&h2_input, &dst).unwrap();
+        let di = CS::Group::hash_to_scalar::<CS::Hash>(&h2_input, &dst).unwrap();
         m = c * &di + &m;
         z = match k_option {
             Some(_) => z,
@@ -378,7 +378,7 @@ where
         // deriveInput = seed || I2OSP(len(info), 2) || info
         // skS = G.HashToScalar(deriveInput || I2OSP(counter, 1), DST = "DeriveKeyPair"
         // || contextString)
-        let sk_s = <CS::Group as Group>::hash_to_scalar::<CS>(
+        let sk_s = CS::Group::hash_to_scalar::<CS::Hash>(
             &[seed, &info_len, info, &counter.to_be_bytes()],
             &dst,
         )
@@ -408,7 +408,8 @@ where
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
     let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(create_context_string::<CS>(mode));
-    let hashed_point = CS::Group::hash_to_curve::<CS>(&[input], &dst).map_err(|_| Error::Input)?;
+    let hashed_point =
+        CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst).map_err(|_| Error::Input)?;
     Ok(hashed_point * blind)
 }
 

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -590,7 +590,7 @@ mod tests {
             IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
     {
         let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(create_context_string::<CS>(mode));
-        let point = CS::Group::hash_to_curve::<CS>(&[input], &dst).unwrap();
+        let point = CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst).unwrap();
 
         let res = point * &key;
 
@@ -705,7 +705,7 @@ mod tests {
             let dst = GenericArray::from(STR_HASH_TO_GROUP)
                 .concat(create_context_string::<CS>(Mode::Oprf));
             // Choose a group element that is unlikely to be the right public key
-            CS::Group::hash_to_curve::<CS>(&[b"msg"], &dst).unwrap()
+            CS::Group::hash_to_curve::<CS::Hash>(&[b"msg"], &dst).unwrap()
         };
         let client_finalize_result =
             VoprfClient::batch_finalize(&inputs, &client_states, &messages, &proof, wrong_pk);
@@ -726,7 +726,7 @@ mod tests {
             let dst = GenericArray::from(STR_HASH_TO_GROUP)
                 .concat(create_context_string::<CS>(Mode::Oprf));
             // Choose a group element that is unlikely to be the right public key
-            CS::Group::hash_to_curve::<CS>(&[b"msg"], &dst).unwrap()
+            CS::Group::hash_to_curve::<CS::Hash>(&[b"msg"], &dst).unwrap()
         };
         let client_finalize_result = client_blind_result.state.finalize(
             input,

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -18,12 +18,12 @@ use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U256};
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "serde")]
-use crate::serialization::serde::{Element, Scalar};
-use crate::util::{
+use crate::common::{
     derive_keypair, deterministic_blind_unchecked, generate_proof, i2osp_2, verify_proof,
     BlindedElement, EvaluationElement, Mode, PreparedEvaluationElement, Proof, STR_FINALIZE,
 };
+#[cfg(feature = "serde")]
+use crate::serialization::serde::{Element, Scalar};
 use crate::{CipherSuite, Error, Group, Result};
 
 ////////////////////////////
@@ -576,8 +576,7 @@ mod tests {
     use rand::rngs::OsRng;
 
     use super::*;
-    use crate::group::STR_HASH_TO_GROUP;
-    use crate::util::create_context_string;
+    use crate::common::{create_context_string, STR_HASH_TO_GROUP};
     use crate::Group;
 
     fn prf<CS: CipherSuite>(


### PR DESCRIPTION
Just some improvements that came to mind while I was working on opaque-ke:
- Rename `util` to `common`, as instead of utility functions this now contains a lot of common functionality between the OPRF modes.
- Relax bounds of `hash_to_scalar` and `hash_to_group` to only what's needed, now that we don't pass in `Mode` anymore.
- The public key generated by `DeriveKeyPair` is thrown away in the OPRF mode, so I split the function up to not unnecessary generate a public key, improving the performance a bit.
- Simplify some `Ristretto255` implementations.