### PR TITLE
Updating to draft 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0-pre.4 (July 9, 2022)
+* Updated to be in sync with draft-irtf-cfrg-voprf-11
+* Adds the evaluate() function to the servers to calculate the output of the OPRF
+  directly
+* Renames the former evaluate() function to blind_evaluate to match the spec
+* Fixes the order of parameters for PoprfClient::blind to align it with the
+  other clients
+
 ## 0.4.0-pre.3 (July 1, 2022)
 * Updated to be in sync with draft-irtf-cfrg-voprf-10, with
   the only difference from -09 being a constant string change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "voprf"
 readme = "README.md"
 repository = "https://github.com/novifinancial/voprf/"
 rust-version = "1.57"
-version = "0.4.0-pre.3"
+version = "0.4.0-pre.4"
 
 [features]
 alloc = []

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-voprf = "0.4.0-pre.3"
+voprf = "0.4.0-pre.4"
 ```
 
 ### Minimum Supported Rust Version

--- a/src/common.rs
+++ b/src/common.rs
@@ -153,7 +153,7 @@ where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
-    // https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-10.html#section-2.2.1
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-11.html#section-2.2.1
 
     let (m, z) = compute_composites::<CS, _, _>(Some(k), b, cs, ds, mode)?;
 
@@ -216,7 +216,7 @@ where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
-    // https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-10.html#section-2.2.2
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-11.html#section-2.2.2
     let (m, z) = compute_composites::<CS, _, _>(None, b, cs, ds, mode)?;
     let t2 = (a * &proof.s_scalar) + &(b * &proof.c_scalar);
     let t3 = (m * &proof.s_scalar) + &(z * &proof.c_scalar);
@@ -285,7 +285,7 @@ where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
-    // https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-10.html#section-2.2.1
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-11.html#section-2.2.1
 
     let elem_len = <CS::Group as Group>::ElemLen::U16.to_be_bytes();
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,7 +11,7 @@ use core::convert::TryFrom;
 
 use derive_where::derive_where;
 use digest::core_api::BlockSizeUser;
-use digest::{Digest, OutputSizeUser};
+use digest::{Digest, Output, OutputSizeUser};
 use generic_array::sequence::Concat;
 use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U11, U2, U256};
 use generic_array::{ArrayLength, GenericArray};
@@ -437,10 +437,59 @@ where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
 {
-    let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(create_context_string::<CS>(mode));
-    let hashed_point =
-        CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst).map_err(|_| Error::Input)?;
+    let hashed_point = hash_to_group::<CS>(input, mode)?;
     Ok(hashed_point * blind)
+}
+
+/// Hashes `input` to a point on the curve
+pub(crate) fn hash_to_group<CS: CipherSuite>(
+    input: &[u8],
+    mode: Mode,
+) -> Result<<CS::Group as Group>::Elem>
+where
+    <CS::Hash as OutputSizeUser>::OutputSize:
+        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
+{
+    let dst = GenericArray::from(STR_HASH_TO_GROUP).concat(create_context_string::<CS>(mode));
+    CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst).map_err(|_| Error::Input)
+}
+
+/// Internal function that finalizes the hash input for OPRF, VOPRF & POPRF.
+/// Returned values can only fail with [`Error::Input`].
+pub(crate) fn server_evaluate_hash_input<CS: CipherSuite>(
+    input: &[u8],
+    info: Option<&[u8]>,
+    issued_element: GenericArray<u8, <<CS as CipherSuite>::Group as Group>::ElemLen>,
+) -> Result<Output<CS::Hash>>
+where
+    <CS::Hash as OutputSizeUser>::OutputSize:
+        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
+{
+    // OPRF & VOPRF
+    // hashInput = I2OSP(len(input), 2) || input ||
+    //             I2OSP(len(issuedElement), 2) || issuedElement ||
+    //             "Finalize"
+    // return Hash(hashInput)
+    //
+    // POPRF
+    // hashInput = I2OSP(len(input), 2) || input ||
+    //             I2OSP(len(info), 2) || info ||
+    //             I2OSP(len(issuedElement), 2) || issuedElement ||
+    //             "Finalize"
+
+    let mut hash = CS::Hash::new()
+        .chain_update(i2osp_2(input.as_ref().len()).map_err(|_| Error::Input)?)
+        .chain_update(input.as_ref());
+    if let Some(info) = info {
+        hash = hash
+            .chain_update(i2osp_2(info.as_ref().len()).map_err(|_| Error::Input)?)
+            .chain_update(info.as_ref());
+    }
+    Ok(hash
+        .chain_update(i2osp_2(issued_element.as_ref().len()).map_err(|_| Error::Input)?)
+        .chain_update(issued_element)
+        .chain_update(STR_FINALIZE)
+        .finalize())
 }
 
 /// Generates the contextString parameter as defined in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,9 +143,11 @@
 //!
 //! ### Server Evaluation
 //!
-//! In the final step on the server side, the server runs [OprfServer::evaluate]
-//! to finish the OPRF protocol by using its private key to produce an output
-//! that is equal to the client's output.
+//! Optionally, if the server has direct access to the PRF input, then it need
+//! not perform the oblivious computation and can simply run
+//! [OprfServer::evaluate] to generate an output which matches the output
+//! produced by an execution of the oblivious protocol on the same input and
+//! key.
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
@@ -305,9 +307,11 @@
 //!
 //! ### Server Evaluation
 //!
-//! In the final step on the server side, the server runs
-//! [VoprfServer::evaluate] to finish the VOPRF protocol by using its private
-//! key to produce an output that is equal to the client's output.
+//! Optionally, if the server has direct access to the PRF input, then it need
+//! not perform the oblivious computation and can simply run
+//! [VoprfServer::evaluate] to generate an output which matches the output
+//! produced by an execution of the oblivious protocol on the same input and
+//! key.
 //!
 //! ```
 //! # #[cfg(feature = "ristretto255")]
@@ -507,7 +511,7 @@
 //! and [PoprfClient] are used, and that each of the functions accept an
 //! additional (and optional) info parameter which represents the public input.
 //! See
-//! <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-10.html#name-poprf-public-input>
+//! <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-11.html#name-poprf-public-input>
 //! for more detailed information on how this public input should be used.
 //!
 //! # Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,9 @@
 //!     .finalize(b"input", &message)
 //!     .expect("Unable to perform client finalization");
 //!
-//! let server_evaluate_result = server.evaluate(b"input").expect("Unable to perform the server evaluation");
+//! let server_evaluate_result = server
+//!     .evaluate(b"input")
+//!     .expect("Unable to perform the server evaluation");
 //!
 //! assert_eq!(client_finalize_result, server_evaluate_result);
 //! ```
@@ -337,7 +339,9 @@
 //!     )
 //!     .expect("Unable to perform client finalization");
 //!
-//! let server_evaluate_result = server.evaluate(b"input").expect("Unable to perform the server evaluation");
+//! let server_evaluate_result = server
+//!     .evaluate(b"input")
+//!     .expect("Unable to perform the server evaluation");
 //!
 //! assert_eq!(client_finalize_result, server_evaluate_result);
 //! ```
@@ -378,7 +382,7 @@
 //! }
 //! ```
 //!
-//! Next, the server calls the [VoprfServer::batch_evaluate_prepare] and
+//! Next, the server calls the [VoprfServer::batch_blind_evaluate_prepare] and
 //! [VoprfServer::batch_blind_evaluate_finish] function on a set of client
 //! messages, to produce a corresponding set of messages to be returned to the
 //! client (returned in the same order), along with a single proof:

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -375,11 +375,13 @@ mod tests {
             .finalize(input, &server_result)
             .unwrap();
 
-        // We expect the outputs from client and server to be equal given an identical input
+        // We expect the outputs from client and server to be equal given an identical
+        // input
         let server_evaluate = server.evaluate(input).unwrap();
         assert_eq!(client_finalize, server_evaluate);
 
-        // We expect the outputs from client and server to be different given different inputs
+        // We expect the outputs from client and server to be different given different
+        // inputs
         let wrong_input = b"wrong input";
         let server_evaluate = server.evaluate(wrong_input).unwrap();
         assert!(client_finalize != server_evaluate);

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -350,8 +350,8 @@ where
         })
     }
 
-    /// See [`batch_evaluate_prepare`](Self::batch_evaluate_prepare) for more
-    /// details.
+    /// See [`batch_blind_evaluate_prepare`](Self::batch_blind_evaluate_prepare)
+    /// for more details.
     ///
     /// # Errors
     /// [`Error::Batch`] if the number of `blinded_elements` and
@@ -904,11 +904,13 @@ mod tests {
             )
             .unwrap();
 
-        // We expect the outputs from client and server to be equal given an identical input
+        // We expect the outputs from client and server to be equal given an identical
+        // input
         let server_evaluate = server.evaluate(input, info).unwrap();
         assert_eq!(client_finalize, server_evaluate);
 
-        // We expect the outputs from client and server to be different given different inputs
+        // We expect the outputs from client and server to be different given different
+        // inputs
         let wrong_input = b"wrong input";
         let server_evaluate = server.evaluate(wrong_input, info).unwrap();
         assert!(client_finalize != server_evaluate);

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -311,10 +311,10 @@ where
         Ok(VoprfServerBatchEvaluateResult { messages, proof })
     }
 
-    /// Alternative version of `batch_blind_evaluate` without
-    /// memory allocation. Returned [`PreparedEvaluationElement`] have to be
+    /// Alternative version of `batch_blind_evaluate` without memory allocation.
+    /// Returned [`PreparedEvaluationElement`] have to be
     /// [`collect`](Iterator::collect)ed and passed into
-    /// [`batch_blind_evaluate_finish`](Self::batch_evaluate_finish).
+    /// [`batch_blind_evaluate_finish`](Self::batch_blind_evaluate_finish).
     pub fn batch_blind_evaluate_prepare<'a, I: Iterator<Item = &'a BlindedElement<CS>>>(
         &self,
         blinded_elements: I,
@@ -329,8 +329,8 @@ where
             })
     }
 
-    /// See [`batch_evaluate_prepare`](Self::batch_evaluate_prepare) for more
-    /// details.
+    /// See [`batch_blind_evaluate_prepare`](Self::batch_blind_evaluate_prepare)
+    /// for more details.
     ///
     /// # Errors
     /// [`Error::Batch`] if the number of `blinded_elements` and
@@ -448,7 +448,7 @@ where
 }
 
 /// Concrete type of [`EvaluationElement`]s returned by
-/// [`VoprfServer::batch_evaluate_prepare`].
+/// [`VoprfServer::batch_blind_evaluate_prepare`].
 pub type VoprfServerBatchEvaluatePreparedEvaluationElements<CS, I> = Map<
     Zip<I, Repeat<<<CS as CipherSuite>::Group as Group>::Scalar>>,
     fn(
@@ -774,11 +774,13 @@ mod tests {
             )
             .unwrap();
 
-        // We expect the outputs from client and server to be equal given an identical input
+        // We expect the outputs from client and server to be equal given an identical
+        // input
         let server_evaluate = server.evaluate(input).unwrap();
         assert_eq!(client_finalize, server_evaluate);
 
-        // We expect the outputs from client and server to be different given different inputs
+        // We expect the outputs from client and server to be different given different
+        // inputs
         let wrong_input = b"wrong input";
         let server_evaluate = server.evaluate(wrong_input).unwrap();
         assert!(client_finalize != server_evaluate);


### PR DESCRIPTION
This PR updates the implementation to draft-11: 

 - The main change is that it introduces `evaluate()` on the server-side and renames the existing `evaluate()` to `blind_evaluate()` to match the spec.
 - Adds unit tests and completes the vector tests
 - Adds documentation with sample code

Miscellaneous change: The PR inverts the order of arguments for `PoprfClient::blind()` to align it with the other clients.

@kevinlewi I'm not sure the renaming/documentation is to your liking, happy to make changes.
