### PR TITLE
Update `curve25519-dalek` to 4.0.0-pre.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         backend_feature:
-          - --features ristretto255-ciphersuite,ristretto255-u64
-          - --features ristretto255-ciphersuite,ristretto255-u32
+          - --features ristretto255-ciphersuite
           -
         frontend_feature:
           -
@@ -88,8 +87,7 @@ jobs:
           - thumbv6m-none-eabi
         backend_feature:
           -
-          - --features ristretto255-ciphersuite,ristretto255-u64
-          - --features ristretto255-ciphersuite,ristretto255-u32
+          - --features ristretto255-ciphersuite
         frontend_feature:
           -
           - --features danger

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,16 @@ version = "0.4.0"
 [features]
 alloc = []
 danger = []
-default = ["ristretto255-ciphersuite", "ristretto255-u64", "serde"]
+default = ["ristretto255-ciphersuite", "serde"]
 ristretto255 = ["curve25519-dalek", "generic-array/more_lengths"]
 ristretto255-ciphersuite = ["ristretto255", "sha2"]
-ristretto255-fiat-u32 = ["curve25519-dalek/fiat_u32_backend", "ristretto255"]
-ristretto255-fiat-u64 = ["curve25519-dalek/fiat_u64_backend", "ristretto255"]
-ristretto255-simd = ["curve25519-dalek/simd_backend", "ristretto255"]
-ristretto255-u32 = ["curve25519-dalek/u32_backend", "ristretto255"]
-ristretto255-u64 = ["curve25519-dalek/u64_backend", "ristretto255"]
 serde = ["generic-array/serde", "serde_"]
 std = ["alloc"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0-pre.1", default-features = false, optional = true }
+curve25519-dalek = { version = "=4.0.0-pre.5", default-features = false, features = [
+  "rand_core",
+], optional = true }
 derive-where = { version = "1", features = ["zeroize-on-drop"] }
 digest = "0.10"
 displaydoc = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,6 @@ regex = "1"
 sha2 = "0.10"
 
 [package.metadata.docs.rs]
-features = ["danger", "std"]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 targets = []

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -22,8 +22,6 @@ use crate::{Error, InternalError, Result};
 
 /// [`Group`] implementation for Ristretto255.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-// `cfg` here is only needed because of a bug in Rust's crate feature documentation. See: https://github.com/rust-lang/rust/issues/83428
-#[cfg(feature = "ristretto255")]
 pub struct Ristretto255;
 
 #[cfg(feature = "ristretto255-ciphersuite")]
@@ -35,8 +33,6 @@ impl crate::CipherSuite for Ristretto255 {
     type Hash = sha2::Sha512;
 }
 
-// `cfg` here is only needed because of a bug in Rust's crate feature documentation. See: https://github.com/rust-lang/rust/issues/83428
-#[cfg(feature = "ristretto255")]
 impl Group for Ristretto255 {
     type Elem = RistrettoPoint;
 

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -104,7 +104,7 @@ impl Group for Ristretto255 {
         loop {
             let scalar = Scalar::random(rng);
 
-            if scalar != Scalar::zero() {
+            if scalar != Scalar::ZERO {
                 break scalar;
             }
         }
@@ -115,12 +115,12 @@ impl Group for Ristretto255 {
     }
 
     fn is_zero_scalar(scalar: Self::Scalar) -> subtle::Choice {
-        scalar.ct_eq(&Scalar::zero())
+        scalar.ct_eq(&Scalar::ZERO)
     }
 
     #[cfg(test)]
     fn zero_scalar() -> Self::Scalar {
-        Scalar::zero()
+        Scalar::ZERO
     }
 
     fn serialize_scalar(scalar: Self::Scalar) -> GenericArray<u8, Self::ScalarLen> {
@@ -131,8 +131,8 @@ impl Group for Ristretto255 {
         scalar_bits
             .try_into()
             .ok()
-            .and_then(Scalar::from_canonical_bytes)
-            .filter(|scalar| scalar != &Scalar::zero())
+            .and_then(|bytes| Scalar::from_canonical_bytes(bytes).into())
+            .filter(|scalar| scalar != &Scalar::ZERO)
             .ok_or(Error::Deserialization)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,21 +532,11 @@
 //!   a [`CipherSuite`].
 //!
 //! - The `ristretto255` feature enables using [`Ristretto255`] as the
-//!   underlying group for the [Group] choice. A backend feature, which are
-//!   re-exported from [curve25519-dalek] and allow for selecting the
-//!   corresponding backend for the curve arithmetic used, has to be selected,
-//!   otherwise compilation will fail. The `ristretto255-u64` feature is
-//!   included as the default. Other features are mapped as `ristretto255-u32`,
-//!   `ristretto255-fiat-u64` and `ristretto255-fiat-u32`. Any `ristretto255-*`
-//!   backend feature will enable the `ristretto255` feature.
-//!
-//! - The `ristretto255-simd` feature is re-exported from [curve25519-dalek] and
-//!   enables parallel formulas, using either AVX2 or AVX512-IFMA. This will
-//!   automatically enable the `ristretto255-u64` feature and requires Rust
-//!   nightly.
+//!   underlying group for the [Group] choice. To select a specific backend see
+//!   the [curve25519-dalek] documentation.
 //!
 //! [curve25519-dalek]:
-//!     (https://doc.dalek.rs/curve25519_dalek/index.html#backends-and-features)
+//!     (https://docs.rs/curve25519-dalek/4.0.0-pre.5/curve25519_dalek/index.html#backends)
 
 #![cfg_attr(not(test), deny(unsafe_code))]
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,8 +538,9 @@
 //! [curve25519-dalek]:
 //!     (https://docs.rs/curve25519-dalek/4.0.0-pre.5/curve25519_dalek/index.html#backends)
 
-#![cfg_attr(not(test), deny(unsafe_code))]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(test), deny(unsafe_code))]
 #![warn(
     clippy::cargo,
     clippy::missing_errors_doc,


### PR DESCRIPTION
There has now been some significant positive movement on `curve25519`, including updated dependencies.
I also added the `doc_auto_cfg` feature behind a `docsrs` `cfg` flag to improve the documentation generated.

I guess for us the biggest change is removing all the re-exported crate features. Now `--all-features` can be used and features are additive, as they should be.

CI might need to be improved now, like testing `--all-features` or 32-bit targets. @kevinlewi I gave you write access, so feel free to add more tests as you deem fit.